### PR TITLE
Swift 2.0 update

### DIFF
--- a/src/TechStacks.xcodeproj/project.pbxproj
+++ b/src/TechStacks.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		25CAD1011BB8BEE5007800C2 /* TechStacks.dtos.extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CAD1001BB8BEE5007800C2 /* TechStacks.dtos.extras.swift */; settings = {ASSET_TAGS = (); }; };
 		5162D4321A8234D7005AC7E2 /* TechnologiesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5162D4311A8234D7005AC7E2 /* TechnologiesViewController.swift */; };
 		5162D4341A82B82D005AC7E2 /* TechnologyDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5162D4331A82B82D005AC7E2 /* TechnologyDetailViewController.swift */; };
 		51A0817D1A7F6DB5000590E9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A0817C1A7F6DB5000590E9 /* AppDelegate.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		25CAD1001BB8BEE5007800C2 /* TechStacks.dtos.extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TechStacks.dtos.extras.swift; sourceTree = "<group>"; };
 		5162D4311A8234D7005AC7E2 /* TechnologiesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TechnologiesViewController.swift; sourceTree = "<group>"; };
 		5162D4331A82B82D005AC7E2 /* TechnologyDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TechnologyDetailViewController.swift; sourceTree = "<group>"; };
 		51A081771A7F6DB5000590E9 /* TechStacks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TechStacks.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -99,6 +101,7 @@
 				51A081871A7F6DB6000590E9 /* LaunchScreen.xib */,
 				51A081FB1A80455B000590E9 /* JsonServiceClient.swift */,
 				51A081F41A7F73FC000590E9 /* TechStacks.dtos.swift */,
+				25CAD1001BB8BEE5007800C2 /* TechStacks.dtos.extras.swift */,
 				51D0210A1A87875C007D973F /* Image.xcassets */,
 			);
 			path = TechStacks;
@@ -190,6 +193,7 @@
 				51F0B9BB1A809803003910E7 /* UIExtensions.swift in Sources */,
 				51F0B9B91A8090E8003910E7 /* HeaderViewController.swift in Sources */,
 				51F0B9BD1A80A0D1003910E7 /* AppData.swift in Sources */,
+				25CAD1011BB8BEE5007800C2 /* TechStacks.dtos.extras.swift in Sources */,
 				51A0817D1A7F6DB5000590E9 /* AppDelegate.swift in Sources */,
 				5162D4341A82B82D005AC7E2 /* TechnologyDetailViewController.swift in Sources */,
 				51A0817F1A7F6DB5000590E9 /* HomeViewController.swift in Sources */,

--- a/src/TechStacks.xcodeproj/project.pbxproj
+++ b/src/TechStacks.xcodeproj/project.pbxproj
@@ -139,7 +139,8 @@
 		51A0816F1A7F6DB5000590E9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "ServiceStack LLC";
 				TargetAttributes = {
 					51A081761A7F6DB5000590E9 = {
@@ -241,6 +242,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -310,6 +312,7 @@
 				CODE_SIGN_IDENTITY = "";
 				INFOPLIST_FILE = TechStacks/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.servicestack.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "10d93fff-f3de-4ba2-949d-991ad38ab468";
 			};
@@ -321,6 +324,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = TechStacks/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.servicestack.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "8f230894-4da2-4acc-8942-c3eda71fa60a";
 			};

--- a/src/TechStacks/AppData.swift
+++ b/src/TechStacks/AppData.swift
@@ -84,13 +84,7 @@ public class AppData : NSObject
     func searchTechStacks(query:String) -> Promise<FindTechStacksResponse> {
         self.search = query
         
-        let qry = query as String
-        let request = FindTechStacks()
-        
-        var dict: [String: String]
-        dict = ["NameContains":qry, "DescriptionContains":qry]
-        
-        return client.getAsync(request, query: dict)
+        return client.getAsync(FindTechStacks(), query: ["NameContains":query, "DescriptionContains":query])
             .then({(r:FindTechStacksResponse) -> FindTechStacksResponse in
                 self.filteredTechStacks = r.results
                 return r
@@ -113,9 +107,8 @@ public class AppData : NSObject
     
     func searchTechnologies(query:String) -> Promise<FindTechnologiesResponse> {
         self.search = query
-        
-        let request = FindTechnologies()
-        return client.getAsync(request, query:["NameContains":query, "DescriptionContains":query])
+
+        return client.getAsync(FindTechnologies(), query:["NameContains":query, "DescriptionContains":query])
             .then({(r:FindTechnologiesResponse) -> FindTechnologiesResponse in
                 self.filteredTechnologies = r.results
                 return r

--- a/src/TechStacks/AppData.swift
+++ b/src/TechStacks/AppData.swift
@@ -43,7 +43,7 @@ public class AppData : NSObject
     
     func loadOverview() -> Promise<AppOverviewResponse> {
         return client.getAsync(AppOverview())
-            .then(body:{(r:AppOverviewResponse) -> AppOverviewResponse in
+            .then({(r:AppOverviewResponse) -> AppOverviewResponse in
                 self.overview = r
                 self.allTiers = r.allTiers
                 self.topTechnologies = r.topTechnologies
@@ -53,7 +53,7 @@ public class AppData : NSObject
     
     func loadAllTechnologies() -> Promise<GetAllTechnologiesResponse> {
         return client.getAsync(GetAllTechnologies())
-            .then(body:{(r:GetAllTechnologiesResponse) -> GetAllTechnologiesResponse in
+            .then({(r:GetAllTechnologiesResponse) -> GetAllTechnologiesResponse in
                 self.allTechnologies = r.results
                 return r
             })
@@ -61,7 +61,7 @@ public class AppData : NSObject
     
     func loadAllTechStacks() -> Promise<GetAllTechnologyStacksResponse> {
         return client.getAsync(GetAllTechnologyStacks())
-            .then(body:{(r:GetAllTechnologyStacksResponse) -> GetAllTechnologyStacksResponse in
+            .then({(r:GetAllTechnologyStacksResponse) -> GetAllTechnologyStacksResponse in
                 self.allTechnologyStacks = r.results
                 return r
             })
@@ -72,21 +72,26 @@ public class AppData : NSObject
             return Promise<GetTechnologyStackResponse> { (complete,reject) in complete(response) }
         }
         
-        var request = GetTechnologyStack()
+        let request = GetTechnologyStack()
         request.slug = slug
         return client.getAsync(request)
-            .then(body:{ (r:GetTechnologyStackResponse) -> GetTechnologyStackResponse in
+            .then({ (r:GetTechnologyStackResponse) -> GetTechnologyStackResponse in
                 self.technologyStackCache[r.result!.slug!] = r
                 return r
             })
     }
     
-    func searchTechStacks(query:String) -> Promise<QueryResponse<TechnologyStack>> {
+    func searchTechStacks(query:String) -> Promise<FindTechStacksResponse> {
         self.search = query
         
-        let request = FindTechStacks<TechnologyStack>()
-        return client.getAsync(request, query:["NameContains":query, "DescriptionContains":query])
-            .then(body:{(r:QueryResponse<TechnologyStack>) -> QueryResponse<TechnologyStack> in
+        let qry = query as String
+        let request = FindTechStacks()
+        
+        var dict: [String: String]
+        dict = ["NameContains":qry, "DescriptionContains":qry]
+        
+        return client.getAsync(request, query: dict)
+            .then({(r:FindTechStacksResponse) -> FindTechStacksResponse in
                 self.filteredTechStacks = r.results
                 return r
             })
@@ -97,21 +102,21 @@ public class AppData : NSObject
             return Promise<GetTechnologyResponse> { (complete,reject) in complete(response) }
         }
         
-        var request = GetTechnology()
+        let request = GetTechnology()
         request.slug = slug
         return client.getAsync(request)
-            .then(body:{ (r:GetTechnologyResponse) -> GetTechnologyResponse in
+            .then({ (r:GetTechnologyResponse) -> GetTechnologyResponse in
                 self.technologyCache[r.technology!.slug!] = r
                 return r
             })
     }
     
-    func searchTechnologies(query:String) -> Promise<QueryResponse<Technology>> {
+    func searchTechnologies(query:String) -> Promise<FindTechnologiesResponse> {
         self.search = query
         
-        let request = FindTechnologies<Technology>()
+        let request = FindTechnologies()
         return client.getAsync(request, query:["NameContains":query, "DescriptionContains":query])
-            .then(body:{(r:QueryResponse<Technology>) -> QueryResponse<Technology> in
+            .then({(r:FindTechnologiesResponse) -> FindTechnologiesResponse in
                 self.filteredTechnologies = r.results
                 return r
             })
@@ -131,7 +136,7 @@ public class AppData : NSObject
         return Promise<[String:UIImage?]> { (complete, reject) in
             for url in urls {
                 self.loadImageAsync(url)
-                    .then(body: { (img:UIImage?) -> Void in
+                    .then({ (img:UIImage?) -> Void in
                         images[url] = img
                         if images.count == urls.count {
                             return complete(images)
@@ -147,7 +152,7 @@ public class AppData : NSObject
         }
         
         return client.getDataAsync(url)
-            .then(body: { (data:NSData) -> UIImage? in
+            .then({ (data:NSData) -> UIImage? in
                 if let image = UIImage(data:data) {
                     self.imageCache[url] = image
                     return image
@@ -167,7 +172,7 @@ public class AppData : NSObject
     }
     
     public func observe(observer: NSObject, property:String) {
-        self.addObserver(observer, forKeyPath: property, options: .New | .Old, context: &ctx)
+        self.addObserver(observer, forKeyPath: property, options: [.New , .Old], context: &ctx)
         
         var properties = observedProperties[observer] ?? [String]()
         properties.append(property)

--- a/src/TechStacks/AppDelegate.swift
+++ b/src/TechStacks/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         //https://coderwall.com/p/dyqrfa/customize-navigation-bar-appearance-with-swift
-        var navigationBarAppearace = UINavigationBar.appearance()
+        let navigationBarAppearace = UINavigationBar.appearance()
         navigationBarAppearace.translucent = false
         navigationBarAppearace.tintColor = UIColor.whiteColor()
         navigationBarAppearace.barTintColor = UIColor(red: 0.0, green: 0.58431372550000005, blue: 0.96078431369999995, alpha: 1.0)

--- a/src/TechStacks/HomeViewController.swift
+++ b/src/TechStacks/HomeViewController.swift
@@ -32,13 +32,15 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.appData.loadOverview()
     }
     
-    override func observeValueForKeyPath(keyPath: String, ofObject object: AnyObject, change: [NSObject : AnyObject], context: UnsafeMutablePointer<Void>) {
-        switch keyPath {
-        case AppData.Property.AllTiers:
-            self.technologyPicker.reloadAllComponents()
-        case AppData.Property.TopTechnologies:
-            self.tblView.reloadData()
-        default: break
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        if let kp = keyPath {
+            switch kp {
+            case AppData.Property.AllTiers:
+                self.technologyPicker.reloadAllComponents()
+            case AppData.Property.TopTechnologies:
+                self.tblView.reloadData()
+            default: break
+            }
         }
     }
     deinit { self.appData.unobserve(self) }
@@ -58,7 +60,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         return appData.allTiers.count
     }
     
-    func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String! {
+    func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         return appData.allTiers[row].title
     }
     
@@ -74,9 +76,13 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         
-        var cell = self.tblView.dequeueReusableCellWithIdentifier("cellHome") as? UITableViewCell
-            ?? UITableViewCell()
-        
+        var cell: UITableViewCell
+        if let viewCell = self.tblView.dequeueReusableCellWithIdentifier("cellHome") as UITableViewCell? {
+            cell = viewCell
+        } else {
+            cell = UITableViewCell()
+        }
+
         cell.accessoryType = UITableViewCellAccessoryType.DisclosureIndicator
         let tech = selectedTechnologies[indexPath.row]
         cell.textLabel?.text = "\(tech.name!) (\(tech.stacksCount!))"

--- a/src/TechStacks/Info.plist
+++ b/src/TechStacks/Info.plist
@@ -2,12 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>techstacks.io</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+		<key>New item</key>
+		<string></string>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.servicestack.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/src/TechStacks/Info.plist
+++ b/src/TechStacks/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>techstacks.io</key>
@@ -14,8 +16,6 @@
 				<false/>
 			</dict>
 		</dict>
-		<key>New item</key>
-		<string></string>
 	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>

--- a/src/TechStacks/JsonServiceClient.swift
+++ b/src/TechStacks/JsonServiceClient.swift
@@ -1,4 +1,4 @@
-/* Url: https://raw.githubusercontent.com/ServiceStack/ServiceStack.Swift/master/dist/JsonServiceClient.swift
+/* Url: https://servicestack.net/dist/JsonServiceClient.swift
 //
 // JsonServiceClient.swift
 // ServiceStackClient

--- a/src/TechStacks/JsonServiceClient.swift
+++ b/src/TechStacks/JsonServiceClient.swift
@@ -16,35 +16,61 @@ public protocol IReturn
     typealias Return : JsonSerializable
 }
 
+public protocol IReturnVoid {}
+
+public protocol IGet {}
+public protocol IPost {}
+public protocol IPut {}
+public protocol IDelete {}
+public protocol IPatch {}
+
 public protocol ServiceClient
 {
-    func get<T : IReturn where T : JsonSerializable>(request:T, error:NSErrorPointer) -> T.Return?
-    func get<T : IReturn where T : JsonSerializable>(request:T, query:[String:String], error:NSErrorPointer) -> T.Return?
-    func get<T : JsonSerializable>(relativeUrl:String, error:NSErrorPointer) -> T?
+    func get<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return
+    func get<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void
+    func get<T : IReturn where T : JsonSerializable>(request:T, query:[String:String]) throws -> T.Return
+    func get<T : JsonSerializable>(relativeUrl:String) throws -> T
     func getAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return>
+    func getAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void>
     func getAsync<T : IReturn where T : JsonSerializable>(request:T, query:[String:String]) -> Promise<T.Return>
     func getAsync<T : JsonSerializable>(relativeUrl:String) -> Promise<T>
     
-    func post<T : IReturn where T : JsonSerializable>(request:T, error:NSErrorPointer) -> T.Return?
-    func post<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?, error:NSErrorPointer) -> Response?
+    func post<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return
+    func post<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void
+    func post<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) throws -> Response
     func postAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return>
+    func postAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void>
+    func postAsync<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) -> Promise<Response>
     
-    func put<T : IReturn where T : JsonSerializable>(request:T, error:NSErrorPointer) -> T.Return?
-    func put<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?, error:NSErrorPointer) -> Response?
+    func put<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return
+    func put<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void
+    func put<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) throws -> Response
     func putAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return>
+    func putAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void>
     func putAsync<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) -> Promise<Response>
     
-    func delete<T : IReturn where T : JsonSerializable>(request:T, error:NSErrorPointer) -> T.Return?
-    func delete<T : IReturn where T : JsonSerializable>(request:T, query:[String:String], error:NSErrorPointer) -> T.Return?
-    func delete<T : JsonSerializable>(relativeUrl:String, error:NSErrorPointer) -> T?
+    func delete<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return
+    func delete<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void
+    func delete<T : IReturn where T : JsonSerializable>(request:T, query:[String:String]) throws -> T.Return
+    func delete<T : JsonSerializable>(relativeUrl:String) throws -> T
     func deleteAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return>
+    func deleteAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void>
     func deleteAsync<T : IReturn where T : JsonSerializable>(request:T, query:[String:String]) -> Promise<T.Return>
     func deleteAsync<T : JsonSerializable>(relativeUrl:String) -> Promise<T>
     
-    func send<T : JsonSerializable>(intoResponse:T, request:NSMutableURLRequest, error:NSErrorPointer) -> T?
+    func patch<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return
+    func patch<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void
+    func patch<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) throws -> Response
+    func patchAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return>
+    func patchAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void>
+    func patchAsync<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) -> Promise<Response>
+    
+    func send<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return
+    func send<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void
+    func send<T : JsonSerializable>(intoResponse:T, request:NSMutableURLRequest) throws -> T
     func sendAsync<T : JsonSerializable>(intoResponse:T, request:NSMutableURLRequest) -> Promise<T>
     
-    func getData(url:String, error:NSErrorPointer) -> NSData?
+    func getData(url:String) throws -> NSData
     func getDataAsync(url:String) -> Promise<NSData>
 }
 
@@ -69,21 +95,11 @@ public class JsonServiceClient : ServiceClient
         static var onError:((NSError) -> Void)?
     }
     
-    public struct HttpMethods {
-        static let Get = "GET"
-        static let Post = "POST"
-        static let Put = "PUT"
-        static let Delete = "DELTE"
-        static let Head = "HEAD"
-        static let Option = "OPTION"
-        static let Path = "PATCH"
-    }
-    
     public init(baseUrl:String)
     {
         self.baseUrl = baseUrl.hasSuffix("/") ? baseUrl : baseUrl + "/"
         self.replyUrl = self.baseUrl + "json/reply/"
-        var url = NSURL(string: self.baseUrl)
+        let url = NSURL(string: self.baseUrl)
         self.domain = url!.host!
     }
     
@@ -111,11 +127,11 @@ public class JsonServiceClient : ServiceClient
     }
     
     func getItem(map:NSDictionary, key:String) -> AnyObject? {
-        return map[String(key[0]).lowercaseString + key[1..<key.count]] ?? map[String(key[0]).uppercaseString + key[1..<key.count]]
+        return map[String(key[0]).lowercaseString + key[1..<key.length]] ?? map[String(key[0]).uppercaseString + key[1..<key.length]]
     }
     
     func populateResponseStatusFields(inout errorInfo:[NSObject : AnyObject], withObject:AnyObject) {
-        if let status = getItem(withObject as NSDictionary, key: "ResponseStatus") as? NSDictionary {
+        if let status = getItem(withObject as! NSDictionary, key: "ResponseStatus") as? NSDictionary {
             if let errorCode = getItem(status, key: "errorCode") as? NSString {
                 errorInfo["errorCode"] = errorCode
             }
@@ -131,8 +147,7 @@ public class JsonServiceClient : ServiceClient
         }
     }
     
-    func handleResponse<T : JsonSerializable>(intoResponse:T, data:NSData, response:NSURLResponse, error:NSErrorPointer) -> T? {
-        
+    func handleResponse<T : JsonSerializable>(intoResponse:T, data:NSData, response:NSURLResponse, error:NSErrorPointer = nil) -> T? {
         if let nsResponse = response as? NSHTTPURLResponse {
             if nsResponse.statusCode >= 400 {
                 var errorInfo = [NSObject : AnyObject]()
@@ -140,7 +155,7 @@ public class JsonServiceClient : ServiceClient
                 errorInfo["statusCode"] = nsResponse.statusCode
                 errorInfo["statusDescription"] = nsResponse.description
                 
-                if let contentType = nsResponse.allHeaderFields["Content-Type"] as? String {
+                if let _ = nsResponse.allHeaderFields["Content-Type"] as? String {
                     if let obj:AnyObject = parseJsonBytes(data) {
                         errorInfo["response"] = obj
                         errorInfo["errorCode"] = nsResponse.statusCode.toString()
@@ -149,13 +164,17 @@ public class JsonServiceClient : ServiceClient
                     }
                 }
                 
-                var ex = fireErrorCallbacks(NSError(domain:self.domain, code:nsResponse.statusCode, userInfo:errorInfo))
+                let ex = fireErrorCallbacks(NSError(domain:self.domain, code:nsResponse.statusCode, userInfo:errorInfo))
                 if error != nil {
                     error.memory = ex
                 }
                 
                 return nil
             }
+        }
+        
+        if (intoResponse is ReturnVoid) {
+            return intoResponse
         }
         
         if responseFilter != nil {
@@ -166,26 +185,26 @@ public class JsonServiceClient : ServiceClient
         }
         
         if let json = NSString(data: data, encoding: NSUTF8StringEncoding) {
-            if let dto = T.reflect().fromJson(intoResponse, json: json, error:error) {
+            if let dto = Type<T>.fromJson(intoResponse, json: json as String) {
                 return dto
             }
         }
         return nil
     }
     
-    public func createUrl<T : IReturn where T : JsonSerializable>(typeInfo:Type<T.T>, dto:T, query:[String:String] = [:]) -> String {
+    public func createUrl<T : JsonSerializable>(dto:T, query:[String:String] = [:]) -> String {
         var requestUrl = self.replyUrl + T.typeName
         
         var sb = ""
-        for pi in typeInfo.properties {
-            if let strValue = pi.stringValue(dto) {
-                sb += sb.count == 0 ? "?" : "&"
-                sb += "\(pi.name)=\(strValue.urlEncode()!)"
+        for pi in T.properties {
+            if let strValue = pi.stringValueAny(dto) {
+                sb += sb.length == 0 ? "?" : "&"
+                sb += "\(pi.name.urlEncode()!)=\(strValue.urlEncode()!)"
             }
         }
         
         for (key,value) in query {
-            sb += sb.count == 0 ? "?" : "&"
+            sb += sb.length == 0 ? "?" : "&"
             sb += "\(key)=\(value.urlEncode()!)"
         }
         
@@ -209,7 +228,7 @@ public class JsonServiceClient : ServiceClient
     public func createRequest(url:String, httpMethod:String, requestType:String? = nil, requestBody:NSData? = nil) -> NSMutableURLRequest {
         let nsUrl = NSURL(string: url)!
         
-        var req = self.timeout == nil
+        let req = self.timeout == nil
             ? NSMutableURLRequest(URL: nsUrl)
             : NSMutableURLRequest(URL: nsUrl, cachePolicy: self.cachePolicy, timeoutInterval: self.timeout!)
         
@@ -232,28 +251,39 @@ public class JsonServiceClient : ServiceClient
         return req
     }
     
-    public func send<T : JsonSerializable>(intoResponse:T, request:NSMutableURLRequest, error:NSErrorPointer = nil) -> T? {
-        
+    public func send<T : JsonSerializable>(intoResponse:T, request:NSMutableURLRequest) throws -> T {
         var response:NSURLResponse? = nil
         
-        if let data = NSURLConnection.sendSynchronousRequest(request, returningResponse: &response, error: error) {
-            return self.handleResponse(intoResponse, data: data, response: response!, error: error)
+        var data = NSData()
+        do {
+            data = try NSURLConnection.sendSynchronousRequest(request, returningResponse: &response)
+            var error:NSError? = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
+            if let dto = self.handleResponse(intoResponse, data: data, response: response!, error: &error) {
+                return dto
+            }
+            if let e = error {
+                throw e
+            }
+            return T()
+        } catch var ex as NSError? {
+            if let e = self.handleResponse(intoResponse, data: data, response: response!, error: &ex) {
+                return e
+            }
+            throw ex!
         }
-        
-        return nil
     }
     
     public func sendAsync<T : JsonSerializable>(intoResponse:T, request:NSMutableURLRequest) -> Promise<T> {
         
         return Promise<T> { (complete, reject) in
             
-            var task = self.createSession().dataTaskWithRequest(request) { (data, response, error) in
+            let task = self.createSession().dataTaskWithRequest(request) { (data, response, error) in
                 if error != nil {
-                    reject(self.handleError(error))
+                    reject(self.handleError(error!))
                 }
                 else {
                     var resposneError:NSError?
-                    let response = self.handleResponse(intoResponse, data: data, response: response, error: &resposneError)
+                    let response = self.handleResponse(intoResponse, data: data!, response: response!, error: &resposneError)
                     if resposneError != nil {
                         reject(self.fireErrorCallbacks(resposneError!))
                     }
@@ -270,104 +300,236 @@ public class JsonServiceClient : ServiceClient
         }
     }
     
-    public func get<T : IReturn where T : JsonSerializable>(request:T, error:NSErrorPointer = nil) -> T.Return? {
-        return send(T.Return(), request: self.createRequest(self.createUrl(T.reflect(), dto: request), httpMethod:HttpMethods.Get), error:error)
+    func resolveUrl(relativeOrAbsoluteUrl:String) -> String {
+        return relativeOrAbsoluteUrl.hasPrefix("http:")
+            || relativeOrAbsoluteUrl.hasPrefix("https:")
+            ? relativeOrAbsoluteUrl
+            : baseUrl.combinePath(relativeOrAbsoluteUrl)
     }
     
-    public func get<T : IReturn where T : JsonSerializable>(request:T, query:[String:String], error:NSErrorPointer = nil) -> T.Return? {
-        return send(T.Return(), request: self.createRequest(self.createUrl(T.reflect(), dto: request, query:query), httpMethod:HttpMethods.Get), error:error)
+    func hasRequestBody(httpMethod:String) -> Bool
+    {
+        switch httpMethod {
+        case HttpMethods.Get, HttpMethods.Delete, HttpMethods.Head, HttpMethods.Options:
+            return false
+        default:
+            return true
+        }
     }
     
-    public func get<T : JsonSerializable>(relativeUrl:String, error:NSErrorPointer = nil) -> T? {
-        return send(T(), request: self.createRequest(baseUrl.combinePath(relativeUrl), httpMethod:HttpMethods.Get), error:error)
+    func getSendMethod<T : JsonSerializable>(request:T) -> String {
+        return request is IGet ?
+            HttpMethods.Get
+            : request is IPost ?
+                HttpMethods.Post
+            : request is IPut ?
+                HttpMethods.Put
+            : request is IDelete ?
+                HttpMethods.Delete
+            : request is IPatch ?
+                HttpMethods.Patch :
+            HttpMethods.Post;
+    }
+    
+    public func send<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return {
+        let httpMethod = getSendMethod(request)
+        return hasRequestBody(httpMethod)
+            ? try send(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:httpMethod, request:request))
+            : try send(T.Return(), request: self.createRequest(self.createUrl(request), httpMethod:httpMethod))
+    }
+    
+    public func send<T : IReturnVoid where T : JsonSerializable>(request:T) throws {
+        let httpMethod = getSendMethod(request)
+        if hasRequestBody(httpMethod) {
+            try send(ReturnVoid.void, request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:httpMethod, request:request))
+        }
+        else {
+            try send(ReturnVoid.void, request: self.createRequest(self.createUrl(request), httpMethod:httpMethod))
+        }
+    }
+    
+    public func sendAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return> {
+        let httpMethod = getSendMethod(request)
+        return hasRequestBody(httpMethod)
+            ? sendAsync(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:httpMethod, request:request))
+            : sendAsync(T.Return(), request: self.createRequest(self.createUrl(request), httpMethod:httpMethod))
+    }
+    
+    public func sendAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void> {
+        let httpMethod = getSendMethod(request)
+        return hasRequestBody(httpMethod)
+            ? sendAsync(ReturnVoid.void, request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Post, request:request))
+                .then({ x -> Void in })
+            : sendAsync(ReturnVoid.void, request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Get))
+                .then({ x -> Void in })
+    }
+    
+    
+    public func get<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return {
+        return try send(T.Return(), request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Get))
+    }
+    
+    public func get<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void {
+        try send(ReturnVoid.void, request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Get))
+    }
+    
+    public func get<T : IReturn where T : JsonSerializable>(request:T, query:[String:String]) throws -> T.Return {
+        return try send(T.Return(), request: self.createRequest(self.createUrl(request, query:query), httpMethod:HttpMethods.Get))
+    }
+    
+    public func get<T : JsonSerializable>(relativeUrl:String) throws -> T {
+        return try send(T(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Get))
     }
     
     public func getAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return> {
-        return sendAsync(T.Return(), request: self.createRequest(self.createUrl(T.reflect(), dto: request), httpMethod:HttpMethods.Get))
+        return sendAsync(T.Return(), request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Get))
+    }
+    
+    public func getAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void> {
+        return sendAsync(ReturnVoid.void, request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Get))
+            .then({ x -> Void in })
     }
     
     public func getAsync<T : IReturn where T : JsonSerializable>(request:T, query:[String:String]) -> Promise<T.Return> {
-        return sendAsync(T.Return(), request: self.createRequest(self.createUrl(T.reflect(), dto: request, query:query), httpMethod:HttpMethods.Get))
+        return sendAsync(T.Return(), request: self.createRequest(self.createUrl(request, query:query), httpMethod:HttpMethods.Get))
     }
     
     public func getAsync<T : JsonSerializable>(relativeUrl:String) -> Promise<T> {
-        return sendAsync(T(), request: self.createRequest(baseUrl.combinePath(relativeUrl), httpMethod:HttpMethods.Get))
+        return sendAsync(T(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Get))
     }
     
     
-    public func post<T : IReturn where T : JsonSerializable>(request:T, error:NSErrorPointer = nil) -> T.Return? {
-        return send(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Post, request:request), error:error)
+    public func post<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return {
+        return try send(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Post, request:request))
     }
     
-    public func post<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?, error:NSErrorPointer = nil) -> Response? {
-        return send(Response(), request: self.createRequest(baseUrl.combinePath(relativeUrl), httpMethod:HttpMethods.Post, request:request), error:error)
+    public func post<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void {
+        try send(ReturnVoid.void, request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Post, request:request))
+    }
+    
+    public func post<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) throws -> Response {
+        return try send(Response(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Post, request:request))
     }
     
     public func postAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return> {
         return sendAsync(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Post, request:request))
     }
     
+    public func postAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void> {
+        return sendAsync(ReturnVoid.void, request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Post, request:request))
+            .then({ x -> Void in })
+    }
+    
     public func postAsync<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) -> Promise<Response> {
-        return sendAsync(Response(), request: self.createRequest(baseUrl.combinePath(relativeUrl), httpMethod:HttpMethods.Post, request:request))
+        return sendAsync(Response(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Post, request:request))
     }
     
     
-    public func put<T : IReturn where T : JsonSerializable>(request:T, error:NSErrorPointer = nil) -> T.Return? {
-        return send(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Put, request:request), error:error)
+    public func put<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return {
+        return try send(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Put, request:request))
     }
     
-    public func put<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?, error:NSErrorPointer = nil) -> Response? {
-        return send(Response(), request: self.createRequest(baseUrl.combinePath(relativeUrl), httpMethod:HttpMethods.Put, request:request), error:error)
+    public func put<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void {
+        try send(ReturnVoid.void, request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Put, request:request))
+    }
+    
+    public func put<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) throws -> Response {
+        return try send(Response(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Put, request:request))
     }
     
     public func putAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return> {
         return sendAsync(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Put, request:request))
     }
     
+    public func putAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void> {
+        return sendAsync(ReturnVoid.void, request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Put, request:request))
+            .then({ x -> Void in })
+    }
+    
     public func putAsync<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) -> Promise<Response> {
-        return sendAsync(Response(), request: self.createRequest(baseUrl.combinePath(relativeUrl), httpMethod:HttpMethods.Put, request:request))
+        return sendAsync(Response(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Put, request:request))
     }
     
     
-    public func delete<T : IReturn where T : JsonSerializable>(request:T, error:NSErrorPointer = nil) -> T.Return? {
-        return send(T.Return(), request: self.createRequest(self.createUrl(T.reflect(), dto: request), httpMethod:HttpMethods.Delete), error:error)
+    public func delete<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return {
+        return try send(T.Return(), request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Delete))
     }
     
-    public func delete<T : IReturn where T : JsonSerializable>(request:T, query:[String:String], error:NSErrorPointer = nil) -> T.Return? {
-        return send(T.Return(), request: self.createRequest(self.createUrl(T.reflect(), dto: request, query:query), httpMethod:HttpMethods.Delete), error:error)
+    public func delete<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void {
+        try send(ReturnVoid.void, request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Delete))
     }
     
-    public func delete<T : JsonSerializable>(relativeUrl:String, error:NSErrorPointer = nil) -> T? {
-        return send(T(), request: self.createRequest(baseUrl.combinePath(relativeUrl), httpMethod:HttpMethods.Delete), error:error)
+    public func delete<T : IReturn where T : JsonSerializable>(request:T, query:[String:String]) throws -> T.Return {
+        return try send(T.Return(), request: self.createRequest(self.createUrl(request, query:query), httpMethod:HttpMethods.Delete))
+    }
+    
+    public func delete<T : JsonSerializable>(relativeUrl:String) throws -> T {
+        return try send(T(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Delete))
     }
     
     public func deleteAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return> {
-        return sendAsync(T.Return(), request: self.createRequest(self.createUrl(T.reflect(), dto: request), httpMethod:HttpMethods.Delete))
+        return sendAsync(T.Return(), request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Delete))
+    }
+    
+    public func deleteAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void> {
+        return sendAsync(ReturnVoid.void, request: self.createRequest(self.createUrl(request), httpMethod:HttpMethods.Delete))
+            .then({ x -> Void in })
     }
     
     public func deleteAsync<T : IReturn where T : JsonSerializable>(request:T, query:[String:String]) -> Promise<T.Return> {
-        return sendAsync(T.Return(), request: self.createRequest(self.createUrl(T.reflect(), dto: request, query:query), httpMethod:HttpMethods.Delete))
+        return sendAsync(T.Return(), request: self.createRequest(self.createUrl(request, query:query), httpMethod:HttpMethods.Delete))
     }
     
     public func deleteAsync<T : JsonSerializable>(relativeUrl:String) -> Promise<T> {
-        return sendAsync(T(), request: self.createRequest(baseUrl.combinePath(relativeUrl), httpMethod:HttpMethods.Delete))
+        return sendAsync(T(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Delete))
     }
-
-    public func getData(url:String, error:NSErrorPointer = nil) -> NSData? {
+    
+    
+    public func patch<T : IReturn where T : JsonSerializable>(request:T) throws -> T.Return {
+        return try send(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Patch, request:request))
+    }
+    
+    public func patch<T : IReturnVoid where T : JsonSerializable>(request:T) throws -> Void {
+        try send(ReturnVoid.void, request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Patch, request:request))
+    }
+    
+    public func patch<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) throws -> Response {
+        return try send(Response(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Patch, request:request))
+    }
+    
+    public func patchAsync<T : IReturn where T : JsonSerializable>(request:T) -> Promise<T.Return> {
+        return sendAsync(T.Return(), request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Patch, request:request))
+    }
+    
+    public func patchAsync<T : IReturnVoid where T : JsonSerializable>(request:T) -> Promise<Void> {
+        return sendAsync(ReturnVoid.void, request: self.createRequest(replyUrl.combinePath(T.typeName), httpMethod:HttpMethods.Patch, request:request))
+            .then({ x -> Void in })
+    }
+    
+    public func patchAsync<Response : JsonSerializable, Request:JsonSerializable>(relativeUrl:String, request:Request?) -> Promise<Response> {
+        return sendAsync(Response(), request: self.createRequest(resolveUrl(relativeUrl), httpMethod:HttpMethods.Patch, request:request))
+    }
+    
+    
+    public func getData(url:String) throws -> NSData {
+        var error: NSError! = NSError(domain: "Migrator", code: 0, userInfo: nil)
         var response:NSURLResponse? = nil
-        if let data = NSURLConnection.sendSynchronousRequest(NSURLRequest(URL: NSURL(string:url)!), returningResponse: &response, error: error) {
+        do {
+            let data = try NSURLConnection.sendSynchronousRequest(NSURLRequest(URL: NSURL(string:resolveUrl(url))!), returningResponse: &response)
             return data
+        } catch let error1 as NSError {
+            error = error1
         }
-        return nil
+        throw error
     }
- 
+    
     public func getDataAsync(url:String) -> Promise<NSData> {
         return Promise<NSData> { (complete, reject) in
-            var task = self.createSession().dataTaskWithURL(NSURL(string: url)!) { (data, response, error) in
+            let task = self.createSession().dataTaskWithURL(NSURL(string: self.resolveUrl(url))!) { (data, response, error) in
                 if error != nil {
-                    reject(self.handleError(error))
+                    reject(self.handleError(error!))
                 }
-                complete(data)
+                complete(data!)
             }
             
             task.resume()
@@ -410,6 +572,16 @@ extension NSHTTPURLResponse {
     }
 }
 
+public struct HttpMethods
+{
+    static let Get = "GET"
+    static let Post = "POST"
+    static let Put = "PUT"
+    static let Delete = "DELTE"
+    static let Head = "HEAD"
+    static let Options = "OPTIONS"
+    static let Patch = "PATCH"
+}
 
 
 
@@ -422,7 +594,7 @@ public class JObject
     }
     
     func append(name: String, json: String?) {
-        if sb.count > 0 {
+        if sb.length > 0 {
             sb += ","
         }
         if let s = json {
@@ -438,7 +610,7 @@ public class JObject
     }
     
     class func toJson<K : Hashable, V : JsonSerializable where K : StringSerializable>(map:[K:V]) -> String? {
-        var jb = JObject()
+        let jb = JObject()
         
         for (k,v) in map {
             jb.append(k.toString(), json: v.toJson())
@@ -457,7 +629,7 @@ public class JArray
     }
     
     func append(json:String?) {
-        if countElements(sb) > 0 {
+        if sb.characters.count > 0 {
             sb += ","
         }
         sb += json != nil ? "\(json!)" : "null"
@@ -470,37 +642,119 @@ public class JArray
 
 public class JValue
 {
-    class func unwrap(any:Any) -> Any? {
-        let mi:MirrorType = reflect(any)
-        if mi.disposition != .Optional {
+    static func unwrap(any:Any) -> Any {
+        
+        let mi = Mirror(reflecting: any)
+        if mi.displayStyle != .Optional {
             return any
         }
-        if mi.count == 0 { return nil } // Optional.None
-        let (name,some) = mi[0]
-        return some.value
+        
+        if mi.children.count == 0 { return NSNull() }
+        let (_, some) = mi.children.first!
+        return some
     }
 }
 
 func parseJson(json:String) -> AnyObject? {
-    var error: NSError?
-    return parseJson(json, &error)
+    do {
+        return try parseJsonThrows(json)
+    } catch _ {
+        return nil
+    }
 }
 
-func parseJson(json:String, error:NSErrorPointer) -> AnyObject? {
+func parseJsonThrows(json:String) throws -> AnyObject {
     let data = json.dataUsingEncoding(NSUTF8StringEncoding)!
-    return parseJsonBytes(data, error)
+    return try parseJsonBytesThrows(data)
 }
 
 func parseJsonBytes(bytes:NSData) -> AnyObject? {
-    var error: NSError?
-    return parseJsonBytes(bytes, &error)
+    do {
+        return try parseJsonBytesThrows(bytes)
+    } catch _ {
+        return nil
+    }
 }
 
-func parseJsonBytes(bytes:NSData, error:NSErrorPointer) -> AnyObject? {
-    let parsedObject: AnyObject? = NSJSONSerialization.JSONObjectWithData(bytes,
-        options: NSJSONReadingOptions.AllowFragments,
-        error:error)
-    return parsedObject
+func parseJsonBytesThrows(bytes:NSData) throws -> AnyObject {
+    var error: NSError! = NSError(domain: "Migrator", code: 0, userInfo: nil)
+    let parsedObject: AnyObject?
+    do {
+        parsedObject = try NSJSONSerialization.JSONObjectWithData(bytes,
+            options: NSJSONReadingOptions.AllowFragments)
+    } catch let error1 as NSError {
+        error = error1
+        parsedObject = nil
+    }
+    if let value = parsedObject {
+        return value
+    }
+    throw error
+}
+
+extension NSString : JsonSerializable
+{
+    public static var typeName:String { return "NSString" }
+    
+    public static var metadata:Metadata = Metadata.create([])
+    
+    public func toString() -> String {
+        return self as String
+    }
+    
+    public func toJson() -> String {
+        return jsonString(self as String)
+    }
+    
+    public static func fromJson(json:String) -> NSString? {
+        return parseJson(json) as? NSString
+    }
+    
+    public static func fromString(string: String) -> NSString? {
+        return string
+    }
+    
+    public static func fromObject(any:AnyObject) -> NSString?
+    {
+        switch any {
+        case let s as NSString: return s
+        default:return nil
+        }
+    }
+}
+
+public class ReturnVoid {
+    public required init(){}
+}
+
+extension ReturnVoid : JsonSerializable
+{
+    public static let void = ReturnVoid()
+    
+    public static var typeName:String { return "ReturnVoid" }
+    
+    public static var metadata:Metadata = Metadata.create([])
+    
+    public func toString() -> String {
+        return ""
+    }
+    
+    public func toJson() -> String {
+        return ""
+    }
+    
+    public static func fromJson(json:String) -> NSString? {
+        return nil
+    }
+    
+    public static func fromString(string: String) -> NSString? {
+        return nil
+    }
+    
+    public static func fromObject(any:AnyObject) -> NSString?
+    {
+        return nil
+    }
 }
 
 extension String : StringSerializable
@@ -528,6 +782,15 @@ extension String : StringSerializable
     }
 }
 
+extension String : JsonSerializable
+{
+    public static var metadata:Metadata = Metadata.create([])
+    
+    public static func fromJson(json:String) -> String? {
+        return parseJson(json) as? String
+    }
+}
+
 extension Character : StringSerializable
 {
     public static var typeName:String { return "Character" }
@@ -541,7 +804,7 @@ extension Character : StringSerializable
     }
     
     public static func fromString(string: String) -> Character? {
-        return string.count > 0 ? string[0] : nil
+        return string.length > 0 ? string[0] : nil
     }
     
     public static func fromObject(any:AnyObject) -> Character?
@@ -558,7 +821,7 @@ extension NSDate : StringSerializable
     public class var typeName:String { return "NSDate" }
     
     public func toString() -> String {
-        return self.isoDateString
+        return self.dateAndTimeString
     }
     
     public func toJson() -> String {
@@ -566,12 +829,17 @@ extension NSDate : StringSerializable
     }
     
     public class func fromString(string: String) -> NSDate? {
-        var str = string.hasPrefix("\\")
-            ? string[1..<string.count]
+        let str = string.hasPrefix("\\")
+            ? string[1..<string.length]
             : string
         let wcfJsonPrefix = "/Date("
         if str.hasPrefix(wcfJsonPrefix) {
-            let unixTime = (str.splitOnFirst("(")[1].splitOnLast(")")[0].splitOnFirst("-")[0].splitOnFirst("+")[0] as NSString).doubleValue
+            let body = str.splitOnFirst("(")[1].splitOnLast(")")[0]
+            let unixTime = (
+                body
+                    .splitOnFirst("-", startIndex:1)[0]
+                    .splitOnFirst("+", startIndex:1)[0] as NSString
+                ).doubleValue
             return NSDate(timeIntervalSince1970: unixTime / 1000) //ms -> secs
         }
         
@@ -619,39 +887,55 @@ extension Double : StringSerializable
 
 extension NSTimeInterval
 {
+    public static let ticksPerSecond:Double = 10000000;
     
-    public func toTimeIntervalString() -> String {
+    public func toXsdDuration() -> String {
         var sb = "P"
         
-        let d = NSDate(timeIntervalSinceNow: self)
-        let now = NSDate()
-        let diff = NSCalendar.currentCalendar().components(NSCalendarUnit.CalendarUnitDay,fromDate:now,toDate:d,options:NSCalendarOptions(0))
+        let totalSeconds:Double = self
+        let wholeSeconds = Int(totalSeconds)
+        var seconds = wholeSeconds
+        let sec = (seconds >= 60 ? seconds % 60 : seconds)
+        seconds = (seconds / 60)
+        let min = seconds >= 60 ? seconds % 60 : seconds
+        seconds = (seconds / 60)
+        let hours = seconds >= 24 ? seconds % 24 : seconds
+        let days = seconds / 24
+        let remainingSecs:Double = Double(sec) + (totalSeconds - Double(wholeSeconds))
         
-        if diff.day > 0 {
-            sb += "\(diff.day)D"
+        if days > 0 {
+            sb += "\(days)D"
         }
         
-        let c = d.components()
-        if c.hour > 0 {
-            sb += "\(c.hour)H"
+        if days == 0 || Double(hours + min + sec) + remainingSecs > 0 {
+            
+            sb += "T"
+            if hours > 0 {
+                sb += "\(hours)H";
+            }
+            if min > 0 {
+                sb += "\(min)M";
+            }
+            
+            if remainingSecs > 0 {
+                var secFmt = String(format:"%.7f", remainingSecs)
+                secFmt = secFmt.trimEnd("0").trimEnd(".")
+                sb += "\(secFmt)S"
+            }
+            else if sb.length == 2 { //PT
+                sb += "0S"
+            }
         }
-        if c.minute > 0 {
-            sb += "\(c.minute)M"
-        }
-        
-        var dateFormatter = NSDateFormatter()
-        dateFormatter.dateFormat = "SSS"
-        let strMs = dateFormatter.stringFromDate(d)
-        
-        sb += strMs != "000"
-            ? "\(c.second).\(strMs)S"
-            : c.second > 0 ? "\(c.second)S" : ""
         
         return sb
     }
     
     public func toTimeIntervalJson() -> String {
         return jsonString(toString())
+    }
+    
+    public static func fromXsdDuration(xsdString:String) -> NSTimeInterval?  {
+        return NSTimeInterval.fromTimeIntervalString(xsdString)
     }
     
     public static func fromTimeIntervalString(string:String) -> NSTimeInterval? {
@@ -661,13 +945,13 @@ extension NSTimeInterval
         var seconds = 0
         var ms = 0.0
         
-        let t = string[1..<string.count].splitOnFirst("T") //strip P
+        let t = string[1..<string.length].splitOnFirst("T") //strip P
         
         let hasTime = t.count == 2
         
         let d = t[0].splitOnFirst("D")
         if d.count == 2 {
-            if let day = d[0].toInt() {
+            if let day = Int(d[0]) {
                 days = day
             }
         }
@@ -675,14 +959,14 @@ extension NSTimeInterval
         if hasTime {
             let h = t[1].splitOnFirst("H")
             if h.count == 2 {
-                if let hour = h[0].toInt() {
+                if let hour = Int(h[0]) {
                     hours = hour
                 }
             }
             
             let m = h.last!.splitOnFirst("M")
             if m.count == 2 {
-                if let min = m[0].toInt() {
+                if let min = Int(m[0]) {
                     minutes = min
                 }
             }
@@ -703,7 +987,6 @@ extension NSTimeInterval
             + (seconds)
         
         let interval = Double(totalSecs) + ms
-        
         
         return interval
     }
@@ -731,7 +1014,7 @@ extension Int : StringSerializable
     }
     
     public static func fromString(str: String) -> Int? {
-        return str.toInt()
+        return Int(str)
     }
     
     public static func fromObject(any:AnyObject) -> Int?
@@ -757,7 +1040,7 @@ extension Int8 : StringSerializable
     }
     
     public static func fromString(str: String) -> Int8? {
-        if let int = str.toInt() {
+        if let int = Int(str) {
             return Int8(int)
         }
         return nil
@@ -786,7 +1069,7 @@ extension Int16 : StringSerializable
     }
     
     public static func fromString(str: String) -> Int16? {
-        if let int = str.toInt() {
+        if let int = Int(str) {
             return Int16(int)
         }
         return nil
@@ -815,7 +1098,7 @@ extension Int32 : StringSerializable
     }
     
     public static func fromString(str: String) -> Int32? {
-        if let int = str.toInt() {
+        if let int = Int(str) {
             return Int32(int)
         }
         return nil
@@ -870,7 +1153,7 @@ extension UInt8 : StringSerializable
     }
     
     public static func fromString(str: String) -> UInt8? {
-        if let int = str.toInt() {
+        if let int = Int(str) {
             return UInt8(int)
         }
         return nil
@@ -899,7 +1182,7 @@ extension UInt16 : StringSerializable
     }
     
     public static func fromString(str: String) -> UInt16? {
-        if let int = str.toInt() {
+        if let int = Int(str) {
             return UInt16(int)
         }
         return nil
@@ -928,7 +1211,7 @@ extension UInt32 : StringSerializable
     }
     
     public static func fromString(str: String) -> UInt32? {
-        if let int = str.toInt() {
+        if let int = Int(str) {
             return UInt32(int)
         }
         return nil
@@ -1024,42 +1307,97 @@ extension Bool : StringSerializable
     }
 }
 
+public class ResponseStatus
+{
+    required public init(){}
+    public var errorCode:String?
+    public var message:String?
+    public var stackTrace:String?
+    public var errors:[ResponseError] = []
+    public var meta:[String:String] = [:]
+}
+
+extension ResponseStatus : JsonSerializable
+{
+    public static var typeName:String { return "ResponseStatus" }
+    public static var metadata = Metadata.create([
+        Type<ResponseStatus>.optionalProperty("errorCode", get: { $0.errorCode }, set: { $0.errorCode = $1 }),
+        Type<ResponseStatus>.optionalProperty("message", get: { $0.message }, set: { $0.message = $1 }),
+        Type<ResponseStatus>.optionalProperty("stackTrace", get: { $0.stackTrace }, set: { $0.stackTrace = $1 }),
+        Type<ResponseStatus>.arrayProperty("errors", get: { $0.errors }, set: { $0.errors = $1 }),
+        Type<ResponseStatus>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+public class ResponseError
+{
+    required public init(){}
+    public var errorCode:String?
+    public var fieldName:String?
+    public var message:String?
+    public var meta:[String:String] = [:]
+}
+
+extension ResponseError : JsonSerializable
+{
+    public static var typeName:String { return "ResponseError" }
+    public static var metadata = Metadata.create([
+        Type<ResponseError>.optionalProperty("errorCode", get: { $0.errorCode }, set: { $0.errorCode = $1 }),
+        Type<ResponseError>.optionalProperty("fieldName", get: { $0.fieldName }, set: { $0.fieldName = $1 }),
+        Type<ResponseError>.optionalProperty("message", get: { $0.message }, set: { $0.message = $1 }),
+        Type<ResponseError>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+public class ErrorResponse
+{
+    required public init(){}
+    public var responseStatus:ResponseStatus?
+}
+
+extension ErrorResponse : JsonSerializable
+{
+    public static var typeName:String { return "ResponseError" }
+    public static var metadata = Metadata.create([
+        Type<ErrorResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+
 
 public class List<T>
 {
     required public init(){}
 }
 
-public protocol HasReflect {
-    typealias T : HasReflect
-    class func reflect() -> Type<T>
+public protocol HasMetadata {
+    static var typeName:String { get }
+    static var metadata:Metadata { get }
     init()
 }
 
 public protocol Convertible {
     typealias T
-    class var typeName:String { get }
-    class func fromObject(any:AnyObject) -> T?
+    static var typeName:String { get }
+    static func fromObject(any:AnyObject) -> T?
 }
 
-public protocol JsonSerializable : HasReflect, StringSerializable {
+public protocol JsonSerializable : HasMetadata, StringSerializable {
     func toJson() -> String
-    class func fromJson(json:String) -> T?
+    static func fromJson(json:String) -> T?
 }
 
 public protocol StringSerializable : Convertible {
     func toJson() -> String
     func toString() -> String
-    class func fromString(string:String) -> T?
+    static func fromString(string:String) -> T?
 }
 
 
-public func populate<T>(instance:T, map:NSDictionary, propertiesMap:[String:PropertyType]) -> T {
+public func populate<T : HasMetadata>(instance:T, map:NSDictionary, propertiesMap:[String:PropertyType]) -> T {
     for (key, obj) in map {
         if let p = propertiesMap[key.lowercaseString] {
-            //insanely this prevents a EXC_BAD_INSTRUCTION when accessing parent.doubleOptional! with a value!
-            //"\(obj)"
-            p.setValue(instance, value: obj)
+            p.setValueAny(instance as! AnyObject, value: obj)
         }
     }
     return instance
@@ -1069,16 +1407,78 @@ public func populateFromDictionary<T : JsonSerializable>(instance:T, map:[NSObje
     for (key, obj) in map {
         if let strKey = key as? String {
             if let p = propertiesMap[strKey.lowercaseString] {
-                p.setValue(instance, value: obj)
+                p.setValueAny(instance as! AnyObject, value: obj)
             }
         }
     }
     return instance
 }
 
+public class Metadata {
+    public var properties:[PropertyType] = []
+    public var propertyMap:[String:PropertyType] = [:]
+    
+    public init(properties:[PropertyType]) {
+        self.properties = properties
+        for p in properties {
+            propertyMap[p.name.lowercaseString] = p
+        }
+    }
+    
+    static func create(properties:[PropertyType]) -> Metadata {
+        return Metadata(properties: properties)
+    }
+}
+
+extension HasMetadata
+{
+    public static var properties:[PropertyType] {
+        return Self.metadata.properties
+    }
+    
+    public static var propertyMap:[String:PropertyType] {
+        return Self.metadata.propertyMap
+    }
+    
+    public func toJson() -> String {
+        let jb = JObject()
+        for p in Self.properties {
+            if let value = p.jsonValueAny(self) {
+                jb.append(p.name, json: value)
+            } else {
+                jb.append(p.name, json: "null")
+            }
+        }
+        return jb.toJson()
+    }
+    
+    public static func fromJson(json:String) -> Self? {
+        if let map = parseJson(json) as? NSDictionary {
+            return populate(Self(), map: map, propertiesMap: Self.propertyMap)
+        }
+        return nil
+    }
+    
+    public static func fromObject(any:AnyObject) -> Self? {
+        switch any {
+        case let s as String: return fromJson(s)
+        case let map as NSDictionary: return populate(Self(), map: map, propertiesMap: Self.propertyMap)
+        default: return nil
+        }
+    }
+    
+    public func toString() -> String {
+        return toJson()
+    }
+    
+    public static func fromString(string:String) -> Self? {
+        return fromJson(string)
+    }
+}
+
 public class TypeAccessor {}
 
-public class Type<T : HasReflect> : TypeAccessor
+public class Type<T : HasMetadata> : TypeAccessor
 {
     var properties: [PropertyType]
     var propertiesMap = [String:PropertyType]()
@@ -1092,10 +1492,10 @@ public class Type<T : HasReflect> : TypeAccessor
         }
     }
     
-    public func toJson<T>(instance:T) -> String {
-        var jb = JObject()
-        for p in properties {
-            if let value = p.jsonValue(instance) {
+    static public func toJson(instance:T) -> String {
+        let jb = JObject()
+        for p in T.properties {
+            if let value = p.jsonValueAny(instance) {
                 jb.append(p.name, json: value)
             } else {
                 jb.append(p.name, json: "null")
@@ -1104,33 +1504,19 @@ public class Type<T : HasReflect> : TypeAccessor
         return jb.toJson()
     }
     
-    public func toString<T>(instance:T) -> String {
+    static public func toString(instance:T) -> String {
         return toJson(instance)
     }
     
-    func fromJson<T : JsonSerializable>(json:String) -> T? {
+    static func fromJson<T : JsonSerializable>(json:String) -> T? {
         return fromJson(T(), json: json)
     }
     
-    func fromJson<T>(instance:T, json:String, error:NSErrorPointer) -> T? {
-        if let map = parseJson(json,error) as? NSDictionary {
-            return populate(instance, map, propertiesMap)
-        }
-        return nil
-    }
-    
-    func fromJson<T>(instance:T, json:String) -> T? {
-        if let map = parseJson(json, nil) as? NSDictionary {
-            return populate(instance, map, propertiesMap)
-        }
-        return nil
-    }
-    
-    func fromString(instance:T, string:String) -> T? {
+    static func fromString<T : JsonSerializable>(instance:T, string:String) -> T? {
         return fromJson(instance, json: string)
     }
     
-    func fromObject(instance:T, any:AnyObject) -> T? {
+    static func fromObject<T : JsonSerializable>(instance:T, any:AnyObject) -> T? {
         switch any {
         case let s as String: return fromJson(instance, json: s)
         case let map as NSDictionary: return Type<T>.fromDictionary(instance, map: map)
@@ -1138,63 +1524,75 @@ public class Type<T : HasReflect> : TypeAccessor
         }
     }
     
-    class func fromDictionary(instance:T, map:NSDictionary) -> T {
-        return populate(instance, map, T.reflect().propertiesMap)
+    static func fromJson<T : JsonSerializable>(instance:T, json:String) -> T? {
+        if instance is NSString || instance is String {
+            if let value = json as? T {
+                return value
+            }
+        }
+        if let map = parseJson(json) as? NSDictionary {
+            return populate(instance, map: map, propertiesMap: T.propertyMap)
+        }
+        return nil
+    }
+    
+    static func fromDictionary<T : HasMetadata>(instance:T, map:NSDictionary) -> T {
+        return populate(instance, map: map, propertiesMap: T.propertyMap)
     }
     
     public class func property<P : StringSerializable>(name:String, get:(T) -> P, set:(T,P) -> Void) -> PropertyType
     {
-        return Property(name: name, get:get, set:set)
+        return JProperty(name: name, get:get, set:set)
     }
     
     public class func optionalProperty<P : StringSerializable>(name:String, get:(T) -> P?, set:(T,P?) -> Void) -> PropertyType
     {
-        return OptionalProperty(name: name, get:get, set:set)
+        return JOptionalProperty(name: name, get:get, set:set)
     }
     
     public class func objectProperty<P : JsonSerializable>(name:String, get:(T) -> P, set:(T,P) -> Void) -> PropertyType
     {
-        return ObjectProperty(name: name, get:get, set:set)
+        return JObjectProperty(name: name, get:get, set:set)
     }
     
     public class func optionalObjectProperty<P : JsonSerializable>(name:String, get:(T) -> P?, set:(T,P?) -> Void) -> PropertyType
     {
-        return OptionalObjectProperty(name: name, get:get, set:set)
+        return JOptionalObjectProperty(name: name, get:get, set:set)
     }
     
     public class func objectProperty<K : Hashable, P : StringSerializable where K : StringSerializable>(name:String, get:(T) -> [K:P], set:(T,[K:P]) -> Void) -> PropertyType
     {
-        return DictionaryProperty(name: name, get:get, set:set)
+        return JDictionaryProperty(name: name, get:get, set:set)
     }
     
     public class func objectProperty<K : Hashable, P : StringSerializable where K : StringSerializable, K == K.T>(name:String, get:(T) -> [K:[P]], set:(T,[K:[P]]) -> Void) -> PropertyType
     {
-        return DictionaryArrayProperty(name: name, get:get, set:set)
+        return JDictionaryArrayProperty(name: name, get:get, set:set)
     }
     
     public class func objectProperty<K : Hashable, P : JsonSerializable where K : StringSerializable>(name:String, get:(T) -> [K:[K:P]], set:(T,[K:[K:P]]) -> Void) -> PropertyType
     {
-        return DictionaryArrayDictionaryObjectProperty(name: name, get:get, set:set)
+        return JDictionaryArrayDictionaryObjectProperty(name: name, get:get, set:set)
     }
     
     public class func arrayProperty<P : StringSerializable>(name:String, get:(T) -> [P], set:(T,[P]) -> Void) -> PropertyType
     {
-        return ArrayProperty(name: name, get:get, set:set)
+        return JArrayProperty(name: name, get:get, set:set)
     }
     
     public class func optionalArrayProperty<P : StringSerializable>(name:String, get:(T) -> [P]?, set:(T,[P]?) -> Void) -> PropertyType
     {
-        return OptionalArrayProperty(name: name, get:get, set:set)
+        return JOptionalArrayProperty(name: name, get:get, set:set)
     }
     
     public class func arrayProperty<P : JsonSerializable>(name:String, get:(T) -> [P], set:(T,[P]) -> Void) -> PropertyType
     {
-        return ArrayObjectProperty(name: name, get:get, set:set)
+        return JArrayObjectProperty(name: name, get:get, set:set)
     }
     
     public class func optionalArrayProperty<P : JsonSerializable>(name:String, get:(T) -> [P]?, set:(T,[P]?) -> Void) -> PropertyType
     {
-        return OptionalArrayObjectProperty(name: name, get:get, set:set)
+        return JOptionalArrayObjectProperty(name: name, get:get, set:set)
     }
 }
 
@@ -1205,23 +1603,67 @@ public class PropertyType {
         self.name = name
     }
     
-    public func jsonValue<T>(instance:T) -> String? {
+    public func jsonValueAny(instance:Any) -> String? {
         return nil
     }
     
-    public func setValue<T>(instance:T, value:AnyObject) {
+    public func setValueAny(instance:Any, value:AnyObject) {
     }
     
-    public func getValue<T>(instance:T) -> Any? {
+    public func getValueAny(instance:Any) -> Any? {
         return nil
     }
     
-    public func stringValue<T>(instance:T) -> String? {
+    public func stringValueAny(instance:Any) -> String? {
+        return nil
+    }
+    
+    public func getName() -> String {
+        return self.name
+    }
+}
+
+public class PropertyBase<T : HasMetadata> : PropertyType {
+    
+    override init(name:String) {
+        super.init(name: name)
+    }
+    
+    public override func jsonValueAny(instance:Any) -> String? {
+        return jsonValue(instance as! T)
+    }
+    
+    public func jsonValue(instance:T) -> String? {
+        return nil
+    }
+    
+    public override func setValueAny(instance:Any, value:AnyObject) {
+        if let t = instance as? T {
+            setValue(t, value: value)
+        }
+    }
+    
+    public func setValue(instance:T, value:AnyObject) {
+    }
+    
+    public override func getValueAny(instance:Any) -> Any? {
+        return getValue(instance as! T)
+    }
+    
+    public func getValue(instance:T) -> Any? {
+        return nil
+    }
+    
+    public override func stringValueAny(instance:Any) -> String? {
+        return stringValue(instance as! T)
+    }
+    
+    public func stringValue(instance:T) -> String? {
         return nil
     }
 }
 
-public class Property<T : HasReflect, P : StringSerializable> : PropertyType
+public class JProperty<T : HasMetadata, P : StringSerializable> : PropertyBase<T>
 {
     public var get:(T) -> P
     public var set:(T,P) -> Void
@@ -1255,10 +1697,10 @@ public class Property<T : HasReflect, P : StringSerializable> : PropertyType
     }
 }
 
-public class OptionalProperty<T : HasReflect, P : StringSerializable> : PropertyType
+public class JOptionalProperty<T : HasMetadata, P : StringSerializable> : PropertyBase<T>
 {
     public var get:(T) -> P?
-    public var set:(T,P) -> Void
+    public var set:(T,P?) -> Void
     
     init(name:String, get:(T) -> P?, set:(T,P?) -> Void)
     {
@@ -1281,6 +1723,13 @@ public class OptionalProperty<T : HasReflect, P : StringSerializable> : Property
         return super.jsonValue(instance)
     }
     
+    public override func getValue(instance:T) -> Any? {
+        if let p = get(instance) {
+            return p
+        }
+        return nil
+    }
+    
     public override func setValue(instance:T, value:AnyObject) {
         if let p = value as? P {
             set(instance, p)
@@ -1292,7 +1741,7 @@ public class OptionalProperty<T : HasReflect, P : StringSerializable> : Property
 }
 
 
-public class ObjectProperty<T : HasReflect, P : JsonSerializable> : PropertyType
+public class JObjectProperty<T : HasMetadata, P : JsonSerializable> : PropertyBase<T>
 {
     public var get:(T) -> P
     public var set:(T,P) -> Void
@@ -1326,10 +1775,10 @@ public class ObjectProperty<T : HasReflect, P : JsonSerializable> : PropertyType
     }
 }
 
-public class OptionalObjectProperty<T : HasReflect, P : JsonSerializable where P : HasReflect> : PropertyType
+public class JOptionalObjectProperty<T : HasMetadata, P : JsonSerializable where P : HasMetadata> : PropertyBase<T>
 {
     public var get:(T) -> P?
-    public var set:(T,P) -> Void
+    public var set:(T,P?) -> Void
     
     init(name:String, get:(T) -> P?, set:(T,P?) -> Void)
     {
@@ -1340,7 +1789,7 @@ public class OptionalObjectProperty<T : HasReflect, P : JsonSerializable where P
     
     public override func jsonValue(instance:T) -> String? {
         if let propValue = get(instance) {
-            var strValue = propValue.toJson()
+            let strValue = propValue.toJson()
             return strValue
         }
         return super.jsonValue(instance)
@@ -1354,7 +1803,7 @@ public class OptionalObjectProperty<T : HasReflect, P : JsonSerializable where P
     }
 }
 
-public class DictionaryProperty<T : HasReflect, K : Hashable, P : StringSerializable where K : StringSerializable> : PropertyType
+public class JDictionaryProperty<T : HasMetadata, K : Hashable, P : StringSerializable where K : StringSerializable> : PropertyBase<T>
 {
     public var get:(T) -> [K:P]
     public var set:(T,[K:P]) -> Void
@@ -1377,7 +1826,7 @@ public class DictionaryProperty<T : HasReflect, K : Hashable, P : StringSerializ
     public override func jsonValue(instance:T) -> String? {
         let map = get(instance)
         
-        var jb = JObject()
+        let jb = JObject()
         for (key, value) in map {
             jb.append(key.toString(), json:value.toJson())
         }
@@ -1399,7 +1848,7 @@ public class DictionaryProperty<T : HasReflect, K : Hashable, P : StringSerializ
     }
 }
 
-public class DictionaryArrayProperty<T : HasReflect, K : Hashable, P : StringSerializable where K : StringSerializable, K == K.T> : PropertyType
+public class JDictionaryArrayProperty<T : HasMetadata, K : Hashable, P : StringSerializable where K : StringSerializable, K == K.T> : PropertyBase<T>
 {
     public var get:(T) -> [K:[P]]
     public var set:(T,[K:[P]]) -> Void
@@ -1422,9 +1871,9 @@ public class DictionaryArrayProperty<T : HasReflect, K : Hashable, P : StringSer
     public override func jsonValue(instance:T) -> String? {
         let map = get(instance)
         
-        var jb = JObject()
+        let jb = JObject()
         for (key, values) in map {
-            var ja = JArray()
+            let ja = JArray()
             for v in values {
                 ja.append(v.toJson())
             }
@@ -1454,7 +1903,7 @@ public class DictionaryArrayProperty<T : HasReflect, K : Hashable, P : StringSer
     }
 }
 
-public class DictionaryArrayDictionaryObjectProperty<T : HasReflect, K : Hashable, P : JsonSerializable where K : StringSerializable> : PropertyType
+public class JDictionaryArrayDictionaryObjectProperty<T : HasMetadata, K : Hashable, P : JsonSerializable where K : StringSerializable> : PropertyBase<T>
 {
     public var get:(T) -> [K:[K:P]]
     public var set:(T,[K:[K:P]]) -> Void
@@ -1477,8 +1926,8 @@ public class DictionaryArrayDictionaryObjectProperty<T : HasReflect, K : Hashabl
     public override func jsonValue(instance:T) -> String? {
         let map = get(instance)
         
-        var jb = JObject()
-        for (key, values:[K:P]) in map {
+        let jb = JObject()
+        for (key, values) in map {
             jb.append(key.toString(), json:JObject.toJson(values))
         }
         return jb.toJson()
@@ -1493,19 +1942,19 @@ public class DictionaryArrayDictionaryObjectProperty<T : HasReflect, K : Hashabl
                     for item in array {
                         if let map = item as? NSDictionary {
                             for (subK, subV) in map {
-                                values[K.fromObject(subK)! as K] = P.fromObject(subV) as? P
+                                values[K.fromObject(subK)! as! K] = P.fromObject(subV) as? P
                             }
                         }
                     }
                 }
-                to[K.fromObject(k) as K] = values
+                to[K.fromObject(k) as! K] = values
             }
             set(instance,to)
         }
     }
 }
 
-public class ArrayProperty<T : HasReflect, P : StringSerializable> : PropertyType
+public class JArrayProperty<T : HasMetadata, P : StringSerializable> : PropertyBase<T>
 {
     public var get:(T) -> [P]
     public var set:(T,[P]) -> Void
@@ -1531,7 +1980,7 @@ public class ArrayProperty<T : HasReflect, P : StringSerializable> : PropertyTyp
         var sb = ""
         
         for item in propValues {
-            if sb.count > 0 {
+            if sb.length > 0 {
                 sb += ","
             }
             var str:String = "null"
@@ -1559,7 +2008,7 @@ public class ArrayProperty<T : HasReflect, P : StringSerializable> : PropertyTyp
     }
 }
 
-public class OptionalArrayProperty<T : HasReflect, P : StringSerializable> : PropertyType
+public class JOptionalArrayProperty<T : HasMetadata, P : StringSerializable> : PropertyBase<T>
 {
     public var get:(T) -> [P]?
     public var set:(T,[P]?) -> Void
@@ -1583,7 +2032,7 @@ public class OptionalArrayProperty<T : HasReflect, P : StringSerializable> : Pro
         var sb = ""
         if let propValues = get(instance) {
             for item in propValues {
-                if sb.count > 0 {
+                if sb.length > 0 {
                     sb += ","
                 }
                 var str:String = "null"
@@ -1614,7 +2063,7 @@ public class OptionalArrayProperty<T : HasReflect, P : StringSerializable> : Pro
     }
 }
 
-public class ArrayObjectProperty<T : HasReflect, P : JsonSerializable> : PropertyType
+public class JArrayObjectProperty<T : HasMetadata, P : JsonSerializable> : PropertyBase<T>
 {
     public var get:(T) -> [P]
     public var set:(T,[P]) -> Void
@@ -1640,7 +2089,7 @@ public class ArrayObjectProperty<T : HasReflect, P : JsonSerializable> : Propert
         var sb = ""
         
         for item in propValues {
-            if sb.count > 0 {
+            if sb.length > 0 {
                 sb += ","
             }
             var str:String = "null"
@@ -1668,7 +2117,7 @@ public class ArrayObjectProperty<T : HasReflect, P : JsonSerializable> : Propert
     }
 }
 
-public class OptionalArrayObjectProperty<T : HasReflect, P : JsonSerializable> : PropertyType
+public class JOptionalArrayObjectProperty<T : HasMetadata, P : JsonSerializable> : PropertyBase<T>
 {
     public var get:(T) -> [P]?
     public var set:(T,[P]?) -> Void
@@ -1689,13 +2138,11 @@ public class OptionalArrayObjectProperty<T : HasReflect, P : JsonSerializable> :
     }
     
     public override func jsonValue(instance:T) -> String? {
-        let propValues = get(instance)
-        
         var sb = ""
         
         if let propValues = get(instance) {
             for item in propValues {
-                if sb.count > 0 {
+                if sb.length > 0 {
                     sb += ","
                 }
                 var str:String = "null"
@@ -1763,14 +2210,13 @@ class Utils
 
 func jsonString(str:String?) -> String {
     if let s = str {
-        if let stringWithEscapeChars = s.rangeOfCharacterFromSet(Utils.escapeChars()) {
-            //TODO: rewrite to encode manually to avoid unnecessary conversions
-            var error:NSError?
-            if let encodedData = NSJSONSerialization.dataWithJSONObject([s], options:NSJSONWritingOptions.allZeros, error:&error) {
+        if let _ = s.rangeOfCharacterFromSet(Utils.escapeChars()) {
+            do {
+                let encodedData = try NSJSONSerialization.dataWithJSONObject([s], options:NSJSONWritingOptions())
                 if let encodedJson = encodedData.toUtf8String() {
-                    return encodedJson[1..<encodedJson.count-1] //strip []
+                    return encodedJson[1..<encodedJson.length-1] //strip []
                 }
-            }
+            } catch { }
         }
         return "\"\(s)\""
     }
@@ -1783,7 +2229,7 @@ func jsonString(str:String?) -> String {
 
 public extension String
 {
-    public var count: Int { return countElements(self) }
+    public var length: Int { return self.characters.count }
     
     public func contains(s:String) -> Bool {
         return (self as NSString).containsString(s)
@@ -1793,8 +2239,18 @@ public extension String
         return (self as String).stringByTrimmingCharactersInSet(.whitespaceCharacterSet())
     }
     
+    public func trimEnd(needle: Character) -> String {
+        var i: Int = self.characters.count - 1, j: Int = i
+        
+        while i >= 0 && self[self.startIndex.advancedBy(i)] == needle {
+            --i
+        }
+        
+        return self.substringWithRange(Range<String.Index>(start: self.startIndex, end: self.endIndex.advancedBy(-(j - i))))
+    }
+    
     public subscript (i: Int) -> Character {
-        return self[advance(self.startIndex, i)]
+        return self[self.startIndex.advancedBy(i)]
     }
     
     public subscript (i: Int) -> String {
@@ -1802,7 +2258,7 @@ public extension String
     }
     
     public subscript (r: Range<Int>) -> String {
-        return substringWithRange(Range(start: advance(startIndex, r.startIndex), end: advance(startIndex, r.endIndex)))
+        return substringWithRange(Range(start: startIndex.advancedBy(r.startIndex), end: startIndex.advancedBy(r.endIndex)))
     }
     
     public func urlEncode() -> String? {
@@ -1810,13 +2266,22 @@ public extension String
     }
     
     public func combinePath(path:String) -> String {
-        return (self.hasSuffix("/") ? self : self + "/") + (path.hasPrefix("/") ? path[1..<path.count] : path)
+        return (self.hasSuffix("/") ? self : self + "/") + (path.hasPrefix("/") ? path[1..<path.length] : path)
     }
     
     public func splitOnFirst(separator:String) -> [String] {
+        return splitOnFirst(separator, startIndex: 0)
+    }
+    
+    public func splitOnFirst(separator:String, startIndex:Int) -> [String] {
         var to = [String]()
-        if let range = self.rangeOfString(separator) {
-            to.append(self[startIndex..<range.startIndex])
+        
+        let startRange = self.startIndex.advancedBy(startIndex)
+        if let range = self.rangeOfString(separator,
+            options: NSStringCompareOptions.LiteralSearch,
+            range: Range<String.Index>(start: startRange, end: self.endIndex))
+        {
+            to.append(self[self.startIndex..<range.startIndex])
             to.append(self[range.endIndex..<endIndex])
         }
         else {
@@ -1843,14 +2308,14 @@ public extension String
     
     public func indexOf(needle:String) -> Int {
         if let range = self.rangeOfString(needle) {
-            return distance(startIndex, range.startIndex)
+            return startIndex.distanceTo(range.startIndex)
         }
         return -1
     }
     
     public func lastIndexOf(needle:String) -> Int {
         if let range = self.rangeOfString(needle, options:NSStringCompareOptions.BackwardsSearch) {
-            return distance(startIndex, range.startIndex)
+            return startIndex.distanceTo(range.startIndex)
         }
         return -1
     }
@@ -1864,7 +2329,7 @@ public extension String
     }
     
     public func print() -> String {
-        println(self)
+        Swift.print(self)
         return self
     }
 }
@@ -1874,12 +2339,12 @@ extension Array
     func print() -> String {
         var sb = ""
         for item in self {
-            if sb.count > 0 {
+            if sb.length > 0 {
                 sb += ","
             }
             sb += "\(item)"
         }
-        println(sb)
+        Swift.print(sb)
         return sb
     }
 }
@@ -1905,11 +2370,8 @@ extension NSError
     }
     
     func populateUserInfo<T : JsonSerializable>(instance:T) -> T? {
-        if let userInfo = self.userInfo {
-            let to = populateFromDictionary(T(), userInfo, T.reflect().propertiesMap)
-            return to
-        }
-        return nil
+        let to = populateFromDictionary(T(), map: self.userInfo, propertiesMap: T.propertyMap)
+        return to
     }
 }
 
@@ -1925,19 +2387,19 @@ public extension NSDate {
     }
     
     public convenience init(year:Int, month:Int, day:Int) {
-        var c = NSDateComponents()
+        let c = NSDateComponents()
         c.year = year
         c.month = month
         c.day = day
         
-        let gregorian = NSCalendar(identifier:NSGregorianCalendar)
+        let gregorian = NSCalendar(identifier:NSCalendarIdentifierGregorian)
         let d = gregorian?.dateFromComponents(c)
         self.init(timeInterval:0, sinceDate:d!)
     }
     
     public func components() -> NSDateComponents {
         let components  = NSCalendar.currentCalendar().components(
-            NSCalendarUnit.DayCalendarUnit | NSCalendarUnit.MonthCalendarUnit | NSCalendarUnit.YearCalendarUnit,
+            [NSCalendarUnit.Day, NSCalendarUnit.Month, NSCalendarUnit.Year],
             fromDate: self)
         
         return components
@@ -1962,8 +2424,15 @@ public extension NSDate {
         return fmt.stringFromDate(self)
     }
     
+    public var dateAndTimeString:String {
+        let fmt = NSDateFormatter()
+        fmt.timeZone = NSTimeZone.defaultTimeZone()
+        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return fmt.stringFromDate(self)
+    }
+    
     public var isoDateString:String {
-        var dateFormatter = NSDateFormatter()
+        let dateFormatter = NSDateFormatter()
         dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         dateFormatter.timeZone = NSTimeZone(abbreviation: "UTC")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
@@ -1972,15 +2441,15 @@ public extension NSDate {
     
     public class func fromIsoDateString(string:String) -> NSDate? {
         let isUtc = string.hasSuffix("Z")
-        var dateFormatter = NSDateFormatter()
+        let dateFormatter = NSDateFormatter()
         dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         dateFormatter.timeZone = isUtc ? NSTimeZone(abbreviation: "UTC") : NSTimeZone.localTimeZone()
-        dateFormatter.dateFormat = string.count == 19
+        dateFormatter.dateFormat = string.length == 19
             ? "yyyy-MM-dd'T'HH:mm:ss"
             : "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS"
         
         return isUtc
-            ? dateFormatter.dateFromString(string[0..<string.count-1])
+            ? dateFormatter.dateFromString(string[0..<string.length-1])
             : dateFormatter.dateFromString(string)
     }
 }
@@ -2002,427 +2471,478 @@ public func <=(lhs: NSDate, rhs: NSDate) -> Bool {
 public func ==(lhs: NSDate, rhs: NSDate) -> Bool {
     return lhs.compare(rhs) == NSComparisonResult.OrderedSame
 }
-/*
-Copyright 2014 Max Howell <mxcl@me.com>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+public let PMKOperationQueue = NSOperationQueue()
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
-
-
-let Q = NSOperationQueue()
-
-private var asskey = "PMKSfjadfl"
-private let policy = UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC) as objc_AssociationPolicy
-
-func PMKRetain(obj: AnyObject) {
-    objc_setAssociatedObject(obj, &asskey, obj, policy)
-}
-
-func PMKRelease(obj: AnyObject) {
-    objc_setAssociatedObject(obj, &asskey, nil, policy)
-}
-
-func noop() {}
-
-public let PMKErrorDomain = "PMKErrorDomain"
-public let PMKURLErrorFailingDataKey = "PMKURLErrorFailingDataKey"
-public let PMKURLErrorFailingStringKey = "PMKURLErrorFailingStringKey"
-public let PMKURLErrorFailingURLResponseKey = "PMKURLErrorFailingURLResponseKey"
-public let PMKJSONErrorJSONObjectKey = "PMKJSONErrorJSONObjectKey"
-public let PMKJSONError = 1
-
-public let NoSuchRecord = 2
-
-private enum State<T> {
-    case Pending(Handlers)
-    case Fulfilled(@autoclosure () -> T) //TODO use plain T, once Swift compiler matures
-    case Rejected(Error)
-}
-
-public class Promise<T> {
-    private let barrier = dispatch_queue_create("org.promisekit.barrier", DISPATCH_QUEUE_CONCURRENT)
-    private var _state: State<T>
-    
-    private var state: State<T> {
-        var result: State<T>?
-        dispatch_sync(barrier) { result = self._state }
-        return result!
-    }
-    
-    public var rejected: Bool {
-        switch state {
-        case .Fulfilled, .Pending: return false
-        case .Rejected: return true
-        }
-    }
-    public var fulfilled: Bool {
-        switch state {
-        case .Rejected, .Pending: return false
-        case .Fulfilled: return true
-        }
-    }
-    public var pending: Bool {
-        switch state {
-        case .Rejected, .Fulfilled: return false
-        case .Pending: return true
-        }
-    }
-    
-    /**
-    returns the fulfilled value unless the Promise is pending
-    or rejected in which case returns `nil`
-    */
-    public var value: T? {
-        switch state {
-        case .Fulfilled(let value):
-            return value()
-        default:
-            return nil
-        }
-    }
-    
-    /**
-    returns the rejected error unless the Promise is pending
-    or fulfilled in which case returns `nil`
-    */
-    public var error: NSError? {
-        switch state {
-        case .Rejected(let error):
-            return error
-        default:
-            return nil
-        }
-    }
-    
-    public init(_ body:(fulfill:(T) -> Void, reject:(NSError) -> Void) -> Void) {
-        _state = .Pending(Handlers())
-        
-        let resolver = { (newstate: State<T>) -> Void in
-            var handlers = Array<()->()>()
-            dispatch_barrier_sync(self.barrier) {
-                switch self._state {
-                case .Pending(let Ω):
-                    self._state = newstate
-                    handlers = Ω.bodies
-                    Ω.bodies.removeAll(keepCapacity: false)
-                default:
-                    noop()
-                }
-            }
-            for handler in handlers { handler() }
-        }
-        
-        body({ resolver(.Fulfilled($0)) }, { error in
-            if let pmkerror = error as? Error {
-                pmkerror.consumed = false
-                resolver(.Rejected(pmkerror))
-            } else {
-                resolver(.Rejected(Error(domain: error.domain, code: error.code, userInfo: error.userInfo)))
-            }
-        })
-    }
-    
-    public class func defer() -> (promise:Promise, fulfill:(T) -> Void, reject:(NSError) -> Void) {
-        var f: ((T) -> Void)?
-        var r: ((NSError) -> Void)?
-        let p = Promise{ f = $0; r = $1 }
-        return (p, f!, r!)
-    }
-    
-    public init(value: T) {
-        _state = .Fulfilled(value)
-    }
-    
-    public init(error: NSError) {
-        _state = .Rejected(Error(domain: error.domain, code: error.code, userInfo: error.userInfo))
-    }
-    
-    public func then<U>(onQueue q:dispatch_queue_t = dispatch_get_main_queue(), body:(T) -> U) -> Promise<U> {
-        return Promise<U>{ (fulfill, reject) in
-            let handler = { ()->() in
-                switch self.state {
-                case .Rejected(let error):
-                    reject(error)
-                case .Fulfilled(let value):
-                    dispatch_async(q) { fulfill(body(value())) }
-                case .Pending:
-                    abort()
-                }
-            }
-            switch self.state {
-            case .Rejected, .Fulfilled:
-                handler()
-            case .Pending(let handlers):
-                dispatch_barrier_sync(self.barrier) {
-                    handlers.append(handler)
-                }
-            }
-        }
-    }
-    
-    public func then<U>(onQueue q:dispatch_queue_t = dispatch_get_main_queue(), body:(T) -> Promise<U>) -> Promise<U> {
-        return Promise<U>{ (fulfill, reject) in
-            let handler = { ()->() in
-                switch self.state {
-                case .Rejected(let error):
-                    reject(error)
-                case .Fulfilled(let value):
-                    dispatch_async(q) {
-                        let promise = body(value())
-                        switch promise.state {
-                        case .Rejected(let error):
-                            reject(error)
-                        case .Fulfilled(let value):
-                            fulfill(value())
-                        case .Pending(let handlers):
-                            dispatch_barrier_sync(promise.barrier) {
-                                handlers.append {
-                                    switch promise.state {
-                                    case .Rejected(let error):
-                                        reject(error)
-                                    case .Fulfilled(let value):
-                                        fulfill(value())
-                                    case .Pending:
-                                        abort()
-                                    }
-                                }
-                            }
-                        }
-                    }
-                case .Pending:
-                    abort()
-                }
-            }
-            
-            switch self.state {
-            case .Rejected, .Fulfilled:
-                handler()
-            case .Pending(let handlers):
-                dispatch_barrier_sync(self.barrier) {
-                    handlers.append(handler)
-                }
-            }
-            
-        }
-    }
-    
-    public func catch(onQueue q:dispatch_queue_t = dispatch_get_main_queue(), body:(NSError) -> T) -> Promise<T> {
-        return Promise<T>{ (fulfill, _) in
-            let handler = { ()->() in
-                switch self.state {
-                case .Rejected(let error):
-                    dispatch_async(q) {
-                        error.consumed = true
-                        fulfill(body(error))
-                    }
-                case .Fulfilled(let value):
-                    fulfill(value())
-                case .Pending:
-                    abort()
-                }
-            }
-            switch self.state {
-            case .Fulfilled, .Rejected:
-                handler()
-            case .Pending(let handlers):
-                dispatch_barrier_sync(self.barrier) {
-                    handlers.append(handler)
-                }
-            }
-        }
-    }
-    
-    public func catch(onQueue q:dispatch_queue_t = dispatch_get_main_queue(), body:(NSError) -> Void) -> Void {
-        let handler = { ()->() in
-            switch self.state {
-            case .Rejected(let error):
-                dispatch_async(q) {
-                    error.consumed = true
-                    body(error)
-                }
-            case .Fulfilled:
-                noop()
-            case .Pending:
-                abort()
-            }
-        }
-        switch self.state {
-        case .Fulfilled, .Rejected:
-            handler()
-        case .Pending(let handlers):
-            dispatch_barrier_sync(self.barrier) {
-                handlers.append(handler)
-            }
-        }
-    }
-    
-    public func catch(onQueue q:dispatch_queue_t = dispatch_get_main_queue(), body:(NSError) -> Promise<T>) -> Promise<T> {
-        return Promise<T>{ (fulfill, reject) in
-            
-            let handler = { ()->() in
-                switch self.state {
-                case .Fulfilled(let value):
-                    fulfill(value())
-                case .Rejected(let error):
-                    dispatch_async(q) {
-                        error.consumed = true
-                        let promise = body(error)
-                        switch promise.state {
-                        case .Fulfilled(let value):
-                            fulfill(value())
-                        case .Rejected(let error):
-                            dispatch_async(q) { reject(error) }
-                        case .Pending(let handlers):
-                            dispatch_barrier_sync(promise.barrier) {
-                                handlers.append {
-                                    switch promise.state {
-                                    case .Rejected(let error):
-                                        reject(error)
-                                    case .Fulfilled(let value):
-                                        fulfill(value())
-                                    case .Pending:
-                                        abort()
-                                    }
-                                }
-                            }
-                        }
-                    }
-                case .Pending:
-                    abort()
-                }
-            }
-            
-            switch self.state {
-            case .Fulfilled, .Rejected:
-                handler()
-            case .Pending(let handlers):
-                dispatch_barrier_sync(self.barrier) {
-                    handlers.append(handler)
-                }
-            }
-        }
-    }
-    
-    //FIXME adding the queue parameter prevents compilation with Xcode 6.0.1
-    public func finally(/*onQueue q:dispatch_queue_t = dispatch_get_main_queue(),*/ body:()->()) -> Promise<T> {
-        let q = dispatch_get_main_queue()
-        
-        return Promise<T>{ (fulfill, reject) in
-            let handler = { ()->() in
-                switch self.state {
-                case .Fulfilled(let value):
-                    dispatch_async(q) {
-                        body()
-                        fulfill(value())
-                    }
-                case .Rejected(let error):
-                    dispatch_async(q) {
-                        body()
-                        reject(error)
-                    }
-                case .Pending:
-                    abort()
-                }
-            }
-            switch self.state {
-            case .Fulfilled, .Rejected:
-                handler()
-            case .Pending(let handlers):
-                dispatch_barrier_sync(self.barrier) {
-                    handlers.append(handler)
-                }
-            }
-        }
-    }
-    
-    /**
-    Immediate resolution of body if the promise is fulfilled.
-    
-    Please note, there are good reasons that `then` does not call `body`
-    immediately if the promise is already fulfilled. If you don’t understand
-    the implications of unleashing zalgo, you should not under any
-    cirumstances use this function!
-    */
-    public func thenUnleashZalgo(body:(T)->Void) -> Void {
-        if let obj = value {
-            body(obj)
-        } else {
-            then(body)
-        }
-    }
-    
-    public func voidify() -> Promise<Void> {
-        // there is no body parameter, so we zalgo it
-        
-        let d = Promise<Void>.defer()
-        
-        let handler = { ()->() in
-            switch self.state {
-            case .Fulfilled:
-                d.fulfill()
-            case .Rejected(let error):
-                d.reject(error)
-            case .Pending:
-                abort()
-            }
-        }
-        
-        switch state {
-        case .Fulfilled, .Rejected:
-            handler()
-        case .Pending(let handlers):
-            dispatch_barrier_sync(self.barrier) {
-                handlers.append(handler)
-            }
-        }
-        
-        return d.promise
-    }
-}
-
-public var PMKUnhandledErrorHandler = { (error: NSError) in
-    NSLog("%@", "PromiseKit: Unhandled error: \(error)")
-}
-
-private class Error : NSError {
-    var consumed: Bool = false  //TODO strictly, should be atomic
-    
-    deinit {
-        if !consumed {
-            PMKUnhandledErrorHandler(self)
-        }
-    }
+public enum CatchPolicy {
+    case AllErrors
+    case AllErrorsExceptCancellation
 }
 
 /**
-When accessing handlers from the State enum, the array
-must not be a copy or we stop being thread-safe. Hence
-this class.
+License: https://github.com/mxcl/PromiseKit#license
+A promise represents the future value of a task.
+
+To obtain the value of a promise we call `then`.
+
+Promises are chainable: `then` returns a promise, you can call `then` on
+that promise, which  returns a promise, you can call `then` on that
+promise, et cetera.
+
+Promises start in a pending state and *resolve* with a value to become
+*fulfilled* or with an `NSError` to become rejected.
+
+@see [PromiseKit `then` Guide](http://promisekit.org/then/)
+@see [PromiseKit Chaining Guide](http://promisekit.org/chaining/)
 */
-private class Handlers: SequenceType {
-    var bodies: [()->()] = []
+public class Promise<T> {
+    let state: State
     
-    func append(body: ()->()) {
+    public convenience init(@noescape resolvers: (fulfill: (T) -> Void, reject: (NSError) -> Void) -> Void) {
+        self.init(sealant: { sealant in
+            resolvers(fulfill: sealant.resolve, reject: sealant.resolve)
+        })
+    }
+    
+    public init(@noescape sealant: (Sealant<T>) -> Void) {
+        var resolve: ((Resolution) -> Void)!
+        state = UnsealedState(resolver: &resolve)
+        sealant(Sealant(body: resolve))
+    }
+    
+    public init(_ value: T) {
+        state = SealedState(resolution: .Fulfilled(value))
+    }
+    
+    public init(_ error: NSError) {
+        unconsume(error)
+        state = SealedState(resolution: .Rejected(error))
+    }
+    
+    init(@noescape passthru: ((Resolution) -> Void) -> Void) {
+        var resolve: ((Resolution) -> Void)!
+        state = UnsealedState(resolver: &resolve)
+        passthru(resolve)
+    }
+    
+    public class func pendingPromise() -> (promise: Promise, fulfill: (T) -> Void, reject: (NSError) -> Void) {
+        var sealant: Sealant<T>!
+        let promise = Promise { sealant = $0 }
+        return (promise, sealant.resolve, sealant.resolve)
+    }
+    
+    func pipe(body: (Resolution) -> Void) {
+        state.get { seal in
+            switch seal {
+            case .Pending(let handlers):
+                handlers.append(body)
+            case .Resolved(let resolution):
+                body(resolution)
+            }
+        }
+    }
+    
+    private convenience init<U>(when: Promise<U>, body: (Resolution, (Resolution) -> Void) -> Void) {
+        self.init(passthru: { resolve in
+            when.pipe{ body($0, resolve) }
+        })
+    }
+    
+    public func then<U>(on q: dispatch_queue_t = dispatch_get_main_queue(), _ body: (T) -> U) -> Promise<U> {
+        return Promise<U>(when: self) { resolution, resolve in
+            switch resolution {
+            case .Rejected:
+                resolve(resolution)
+            case .Fulfilled(let value):
+                contain_zalgo(q) {
+                    resolve(.Fulfilled(body(value as! T)))
+                }
+            }
+        }
+    }
+    
+    public func then<U>(on q: dispatch_queue_t = dispatch_get_main_queue(), _ body: (T) -> Promise<U>) -> Promise<U> {
+        return Promise<U>(when: self) { resolution, resolve in
+            switch resolution {
+            case .Rejected:
+                resolve(resolution)
+            case .Fulfilled(let value):
+                contain_zalgo(q) {
+                    body(value as! T).pipe(resolve)
+                }
+            }
+        }
+    }
+    
+    public func thenInBackground<U>(body: (T) -> U) -> Promise<U> {
+        return then(on: dispatch_get_global_queue(0, 0), body)
+    }
+    
+    public func thenInBackground<U>(body: (T) -> Promise<U>) -> Promise<U> {
+        return then(on: dispatch_get_global_queue(0, 0), body)
+    }
+    
+    public func error(policy policy: CatchPolicy = .AllErrorsExceptCancellation, _ body: (NSError) -> Void) {
+        pipe { resolution in
+            switch resolution {
+            case .Fulfilled:
+                break
+            case .Rejected(let error):
+                dispatch_async(dispatch_get_main_queue()) {
+                    if policy == .AllErrors || !error.cancelled {
+                        consume(error)
+                        body(error)
+                    }
+                }
+            }
+        }
+    }
+    
+    public func recover(on q: dispatch_queue_t = dispatch_get_main_queue(), _ body: (NSError) -> Promise<T>) -> Promise<T> {
+        return Promise(when: self) { resolution, resolve in
+            switch resolution {
+            case .Rejected(let error):
+                contain_zalgo(q) {
+                    consume(error)
+                    body(error).pipe(resolve)
+                }
+            case .Fulfilled:
+                resolve(resolution)
+            }
+        }
+    }
+    
+    public func finally(on q: dispatch_queue_t = dispatch_get_main_queue(), _ body: () -> Void) -> Promise<T> {
+        return Promise(when: self) { resolution, resolve in
+            contain_zalgo(q) {
+                body()
+                resolve(resolution)
+            }
+        }
+    }
+    
+    public var value: T? {
+        switch state.get() {
+        case .None:
+            return nil
+        case .Some(.Fulfilled(let value)):
+            return (value as! T)
+        case .Some(.Rejected):
+            return nil
+        }
+    }
+}
+
+
+public let zalgo: dispatch_queue_t = dispatch_queue_create("Zalgo", nil)
+
+public let waldo: dispatch_queue_t = dispatch_queue_create("Waldo", nil)
+
+func contain_zalgo(q: dispatch_queue_t, block: () -> Void) {
+    if q === zalgo {
+        block()
+    } else if q === waldo {
+        if NSThread.isMainThread() {
+            dispatch_async(dispatch_get_global_queue(0, 0), block)
+        } else {
+            block()
+        }
+    } else {
+        dispatch_async(q, block)
+    }
+}
+
+
+extension Promise {
+    public convenience init(error: String, code: Int = Constants.PMKUnexpectedError) {
+        let error = NSError(domain: Constants.PMKErrorDomain, code: code, userInfo: [NSLocalizedDescriptionKey: error])
+        self.init(error)
+    }
+    
+    public func asAny() -> Promise<Any> {
+        return Promise<Any>(passthru: pipe)
+    }
+    
+    public func asAnyObject() -> Promise<AnyObject> {
+        return Promise<AnyObject>(passthru: pipe)
+    }
+    
+    /**
+    Swift (1.2) seems to be much less fussy about Void promises.
+    */
+    public func asVoid() -> Promise<Void> {
+        return then(on: zalgo) { _ in return }
+    }
+}
+
+
+extension Promise: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "Promise: \(state)"
+    }
+}
+
+public func firstly<T>(promise: () -> Promise<T>) -> Promise<T> {
+    return promise()
+}
+
+public enum ErrorPolicy {
+    case AllErrors
+    case AllErrorsExceptCancellation
+}
+
+extension Promise {
+    public var error: NSError? {
+        switch state.get() {
+        case .None:
+            return nil
+        case .Some(.Fulfilled):
+            return nil
+        case .Some(.Rejected(let error)):
+            return error
+        }
+    }
+    
+    public var pending: Bool {
+        return state.get() == nil
+    }
+    
+    public var resolved: Bool {
+        return !pending
+    }
+    
+    public var fulfilled: Bool {
+        return value != nil
+    }
+    
+    public var rejected: Bool {
+        return error != nil
+    }
+}
+
+public var PMKUnhandledErrorHandler = { (error: NSError) -> Void in
+    dispatch_async(dispatch_get_main_queue()) {
+        if !error.cancelled {
+            NSLog("PromiseKit: Unhandled error: %@", error)
+        }
+    }
+}
+
+private class Consumable: NSObject {
+    let parentError: NSError
+    var consumed: Bool = false
+    
+    deinit {
+        if !consumed {
+            PMKUnhandledErrorHandler(parentError)
+        }
+    }
+    
+    init(parent: NSError) {
+        parentError = parent.copy() as! NSError
+    }
+}
+
+private var handle: UInt8 = 0
+
+func consume(error: NSError) {
+    if let pmke = objc_getAssociatedObject(error, &handle) as? Consumable {
+        pmke.consumed = true
+    }
+}
+
+func unconsume(error: NSError) {
+    if let pmke = objc_getAssociatedObject(error, &handle) as! Consumable? {
+        pmke.consumed = false
+    } else {
+        objc_setAssociatedObject(error, &handle, Consumable(parent: error), .OBJC_ASSOCIATION_RETAIN)
+    }
+}
+
+private struct ErrorPair: Hashable {
+    let domain: String
+    let code: Int
+    init(_ d: String, _ c: Int) {
+        domain = d; code = c
+    }
+    var hashValue: Int {
+        return "\(domain):\(code)".hashValue
+    }
+}
+
+private func ==(lhs: ErrorPair, rhs: ErrorPair) -> Bool {
+    return lhs.domain == rhs.domain && lhs.code == rhs.code
+}
+
+private var cancelledErrorIdentifiers = Set([
+    ErrorPair(Constants.PMKErrorDomain, Constants.PMKOperationCancelled),
+    ErrorPair(NSURLErrorDomain, NSURLErrorCancelled)
+    ])
+
+extension NSError {
+    public class func cancelledError() -> NSError {
+        let info: [NSObject: AnyObject] = [NSLocalizedDescriptionKey: "The operation was cancelled"]
+        return NSError(domain: Constants.PMKErrorDomain, code: Constants.PMKOperationCancelled, userInfo: info)
+    }
+    
+    public class func registerCancelledErrorDomain(domain: String, code: Int) {
+        cancelledErrorIdentifiers.insert(ErrorPair(domain, code))
+    }
+    
+    public var cancelled: Bool {
+        return cancelledErrorIdentifiers.contains(ErrorPair(domain, code))
+    }
+}
+
+public class Sealant<T> {
+    let handler: (Resolution) -> ()
+    
+    init(body: (Resolution) -> Void) {
+        handler = body
+    }
+    
+    func __resolve(obj: AnyObject) {
+        switch obj {
+        case is NSError:
+            resolve(obj as! NSError)
+        default:
+            handler(.Fulfilled(obj))
+        }
+    }
+    
+    public func resolve(value: T) {
+        handler(.Fulfilled(value))
+    }
+    
+    public func resolve(error: NSError!) {
+        unconsume(error)
+        handler(.Rejected(error))
+    }
+    
+    public func resolve(obj: T?, var _ error: NSError?) {
+        if let obj = obj {
+            handler(.Fulfilled(obj))
+        } else if let error = error {
+            resolve(error)
+        } else {
+            //FIXME couldn't get the constants from the umbrella header :(
+            error = NSError(domain: Constants.PMKErrorDomain, code: /*PMKUnexpectedError*/ 1, userInfo: nil)
+            resolve(error)
+        }
+    }
+    
+    public func resolve(obj: T, _ error: NSError?) {
+        if error == nil {
+            handler(.Fulfilled(obj))
+        } else  {
+            resolve(error)
+        }
+    }
+}
+
+enum Resolution {
+    case Fulfilled(Any)    //TODO make type T when Swift can handle it
+    case Rejected(NSError)
+}
+
+enum Seal {
+    case Pending(Handlers)
+    case Resolved(Resolution)
+}
+
+protocol State {
+    func get() -> Resolution?
+    func get(body: (Seal) -> Void)
+}
+
+class UnsealedState: State {
+    private let barrier = dispatch_queue_create("org.promisekit.barrier", DISPATCH_QUEUE_CONCURRENT)
+    private var seal: Seal
+    
+    func get() -> Resolution? {
+        var result: Resolution?
+        dispatch_sync(barrier) {
+            switch self.seal {
+            case .Resolved(let resolution):
+                result = resolution
+            case .Pending:
+                break
+            }
+        }
+        return result
+    }
+    
+    func get(body: (Seal) -> Void) {
+        var sealed = false
+        dispatch_sync(barrier) {
+            switch self.seal {
+            case .Resolved:
+                sealed = true
+            case .Pending:
+                sealed = false
+            }
+        }
+        if !sealed {
+            dispatch_barrier_sync(barrier) {
+                switch (self.seal) {
+                case .Pending:
+                    body(self.seal)
+                case .Resolved:
+                    sealed = true  // welcome to race conditions
+                }
+            }
+        }
+        if sealed {
+            body(seal)
+        }
+    }
+    
+    init(inout resolver: ((Resolution) -> Void)!) {
+        seal = .Pending(Handlers())
+        resolver = { resolution in
+            var handlers: Handlers?
+            dispatch_barrier_sync(self.barrier) {
+                switch self.seal {
+                case .Pending(let hh):
+                    self.seal = .Resolved(resolution)
+                    handlers = hh
+                case .Resolved:
+                    break
+                }
+            }
+            if let handlers = handlers {
+                for handler in handlers {
+                    handler(resolution)
+                }
+            }
+        }
+    }
+}
+
+class SealedState: State {
+    private let resolution: Resolution
+    
+    init(resolution: Resolution) {
+        self.resolution = resolution
+    }
+    
+    func get() -> Resolution? {
+        return resolution
+    }
+    func get(body: (Seal) -> Void) {
+        body(.Resolved(resolution))
+    }
+}
+
+
+class Handlers: SequenceType {
+    var bodies: [(Resolution)->()] = []
+    
+    func append(body: (Resolution)->()) {
         bodies.append(body)
     }
     
-    func generate() -> IndexingGenerator<[()->()]> {
+    func generate() -> IndexingGenerator<[(Resolution)->()]> {
         return bodies.generate()
     }
     
@@ -2431,38 +2951,42 @@ private class Handlers: SequenceType {
     }
 }
 
-extension Promise: DebugPrintable {
-    public var debugDescription: String {
-        var state: State<T>?
-        dispatch_sync(barrier) {
-            state = self._state
-        }
-        
-        switch state! {
-        case .Pending(let handlers):
-            var count: Int?
-            dispatch_sync(barrier) {
-                count = handlers.count
-            }
-            return "Promise: Pending with \(count!) handlers"
-        case .Fulfilled(let value):
-            return "Promise: Fulfilled with value: \(value())"
-        case .Rejected(let error):
-            return "Promise: Rejected with error: \(error)"
+
+extension Resolution: CustomDebugStringConvertible {
+    var debugDescription: String {
+        switch self {
+        case Fulfilled(let value):
+            return "Fulfilled with value: \(value)"
+        case Rejected(let error):
+            return "Rejected with error: \(error)"
         }
     }
 }
 
-func dispatch_promise<T>(/*to q:dispatch_queue_t = dispatch_get_global_queue(0, 0),*/ body:() -> AnyObject) -> Promise<T> {
-    let q = dispatch_get_global_queue(0, 0)
-    return Promise<T> { (fulfill, reject) in
-        dispatch_async(q) {
-            let obj: AnyObject = body()
-            if obj is NSError {
-                reject(obj as NSError)
-            } else {
-                fulfill(obj as T)
+extension UnsealedState: CustomDebugStringConvertible {
+    var debugDescription: String {
+        var rv: String?
+        get { seal in
+            switch seal {
+            case .Pending(let handlers):
+                rv = "Pending with \(handlers.count) handlers"
+            case .Resolved(let resolution):
+                rv = "\(resolution)"
             }
         }
+        return "UnsealedState: \(rv!)"
     }
+}
+
+extension SealedState: CustomDebugStringConvertible {
+    var debugDescription: String {
+        return "SealedState: \(resolution)"
+    }
+}
+
+
+struct Constants {
+    static let PMKErrorDomain = "PMKErrorDomain"
+    static let PMKUnexpectedError = 1
+    static let PMKOperationCancelled = 5
 }

--- a/src/TechStacks/TechStacks.dtos.extras.swift
+++ b/src/TechStacks/TechStacks.dtos.extras.swift
@@ -1,0 +1,123 @@
+//
+//  TechStacks.dtos.extras.swift
+//  TechStacks
+//
+//  Created by Demis Bellot on 2/4/15.
+//  Copyright (c) 2015 ServiceStack LLC. All rights reserved.
+//
+
+import Foundation
+
+// @Route("/technology/search", "GET")
+public class FindTechnologies : NSObject, IReturn
+{
+    public typealias Return = FindTechnologiesResponse
+    
+    required public override init(){}
+    
+    public var skip:Int?
+    public var take:Int?
+    public var orderBy:String?
+    public var orderByDesc:String?
+    public var include:String?
+    public var meta:[String:String] = [:]
+    
+    public var name:String?
+    public var reload:Bool?
+}
+
+// @Route("/techstacks/search", "GET")
+public class FindTechStacks : NSObject, IReturn
+{
+    public typealias Return = FindTechStacksResponse
+    
+    required public override init(){}
+    
+    public var skip:Int?
+    public var take:Int?
+    public var orderBy:String?
+    public var orderByDesc:String?
+    public var include:String?
+    public var meta:[String:String] = [:]
+    
+    public var reload:Bool?
+}
+
+public class FindTechnologiesResponse : NSObject
+{
+    required public override init(){}
+    
+    public var offset:Int?
+    public var total:Int?
+    public var results:[Technology] = []
+    public var meta:[String:String] = [:]
+    public var responseStatus:ResponseStatus?
+}
+
+public class FindTechStacksResponse : NSObject
+{
+    required public override init(){}
+    
+    public var offset:Int?
+    public var total:Int?
+    public var results:[TechnologyStack] = []
+    public var meta:[String:String] = [:]
+    public var responseStatus:ResponseStatus?
+}
+
+extension FindTechnologies : JsonSerializable
+{
+    public static var typeName:String { return "FindTechnologies" }
+    public static var metadata = Metadata.create([
+        Type<FindTechnologies>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<FindTechnologies>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        Type<FindTechnologies>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
+        Type<FindTechnologies>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
+        Type<FindTechnologies>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
+        Type<FindTechnologies>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
+        Type<FindTechnologies>.optionalProperty("include", get: { $0.include }, set: { $0.include = $1 }),
+        Type<FindTechnologies>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+extension FindTechnologiesResponse : JsonSerializable
+{
+    public static var typeName:String { return "FindTechnologiesResponse" }
+    public static var metadata:Metadata {
+        return Metadata.create([
+            Type<FindTechnologiesResponse>.optionalProperty("offset", get: { $0.offset }, set: { $0.offset = $1 }),
+            Type<FindTechnologiesResponse>.optionalProperty("total", get: { $0.total }, set: { $0.total = $1 }),
+            Type<FindTechnologiesResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+            Type<FindTechnologiesResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+            Type<FindTechnologiesResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+            ])
+    }
+}
+
+extension FindTechStacks : JsonSerializable
+{
+    public static var typeName:String { return "FindTechStacks" }
+    public static var metadata = Metadata.create([
+        Type<FindTechStacks>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        Type<FindTechStacks>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
+        Type<FindTechStacks>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
+        Type<FindTechStacks>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
+        Type<FindTechStacks>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
+        Type<FindTechStacks>.optionalProperty("include", get: { $0.include }, set: { $0.include = $1 }),
+        Type<FindTechStacks>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+extension FindTechStacksResponse : JsonSerializable
+{
+    public static var typeName:String { return "FindTechStacksResponse" }
+    public static var metadata:Metadata {
+        return Metadata.create([
+            Type<FindTechStacksResponse>.optionalProperty("offset", get: { $0.offset }, set: { $0.offset = $1 }),
+            Type<FindTechStacksResponse>.optionalProperty("total", get: { $0.total }, set: { $0.total = $1 }),
+            Type<FindTechStacksResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+            Type<FindTechStacksResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+            Type<FindTechStacksResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+            ])
+    }
+}

--- a/src/TechStacks/TechStacks.dtos.swift
+++ b/src/TechStacks/TechStacks.dtos.swift
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2015-09-25 22:11:55
+Date: 2015-09-28 02:10:09
 SwiftVersion: 2.0
 Version: 4.046
 BaseUrl: http://techstacks.io
@@ -9,7 +9,7 @@ BaseClass: NSObject
 //AddServiceStackTypes: True
 //IncludeTypes:
 //ExcludeTypes:
-ExcludeGenericBaseTypes: False
+//ExcludeGenericBaseTypes: True
 //AddResponseStatus: False
 //AddImplicitVersion:
 //InitializeCollections: True
@@ -171,54 +171,7 @@ public class GetAllTechnologies : NSObject, IReturn
     
     required public override init(){}
 }
-
-//** MJC START
-// @Route("/technology/search")
-// @AutoQueryViewer(Title="Find Technologies", Description="Explore different Technologies", IconUrl="/img/app/tech-white-75.png", DefaultSearchField="Tier", DefaultSearchType="=", DefaultSearchText="Data")
-public class FindTechnologies : NSObject, IReturn
-{
-    //public typealias Return = QueryResponse<Technology>
-    public typealias Return = FindTechnologiesResponse
-    
-    required public override init(){}
-    
-    public var skip:Int?
-    public var take:Int?
-    public var orderBy:String?
-    public var orderByDesc:String?
-    public var include:String?
-    public var meta:[String:String] = [:]
-
-    public var name:String?
-    public var reload:Bool?
-}
-
-public class FindTechnologiesResponse : NSObject
-{
-    required public override init(){}
-    
-    public var offset:Int?
-    public var total:Int?
-    public var results:[Technology] = []
-    public var meta:[String:String] = [:]
-    public var responseStatus:ResponseStatus?
-}
-
-extension FindTechnologiesResponse : JsonSerializable
-{
-    public static var typeName:String { return "FindTechnologiesResponse" }
-    public static var metadata:Metadata {
-        return Metadata.create([
-            Type<FindTechStacksResponse>.optionalProperty("offset", get: { $0.offset }, set: { $0.offset = $1 }),
-            Type<FindTechStacksResponse>.optionalProperty("total", get: { $0.total }, set: { $0.total = $1 }),
-            Type<FindTechStacksResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            Type<FindTechStacksResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
-            Type<FindTechStacksResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ])
-    }
-}
-//** MJC END
-
+//Excluded FindTechnologies : QueryBase<Technology>
 
 // @Route("/techstacks", "POST")
 public class CreateTechnologyStack : NSObject, IReturn
@@ -324,52 +277,7 @@ public class AppOverview : NSObject, IReturn
     required public override init(){}
     public var reload:Bool?
 }
-
-//** MJC START
-// @Route("/techstacks/search")
-// @AutoQueryViewer(Title="Find Technology Stacks", Description="Explore different Technology Stacks", IconUrl="/img/app/stacks-white-75.png", DefaultSearchField="Description", DefaultSearchType="Contains", DefaultSearchText="ServiceStack")
-public class FindTechStacks : NSObject, IReturn
-{
-    //public typealias Return = QueryResponse<TechnologyStack>
-    public typealias Return = FindTechStacksResponse
-    
-    required public override init(){}
-    
-    public var skip:Int?
-    public var take:Int?
-    public var orderBy:String?
-    public var orderByDesc:String?
-    public var include:String?
-    public var meta:[String:String] = [:]
-    
-    public var reload:Bool?
-}
-
-public class FindTechStacksResponse : NSObject
-{
-    required public override init(){}
-    
-    public var offset:Int?
-    public var total:Int?
-    public var results:[TechnologyStack] = []
-    public var meta:[String:String] = [:]
-    public var responseStatus:ResponseStatus?
-}
-
-extension FindTechStacksResponse : JsonSerializable
-{
-    public static var typeName:String { return "FindTechStacksResponse" }
-    public static var metadata:Metadata {
-        return Metadata.create([
-            Type<FindTechStacksResponse>.optionalProperty("offset", get: { $0.offset }, set: { $0.offset = $1 }),
-            Type<FindTechStacksResponse>.optionalProperty("total", get: { $0.total }, set: { $0.total = $1 }),
-            Type<FindTechStacksResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            Type<FindTechStacksResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
-            Type<FindTechStacksResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ])
-    }
-}
-//** MJC END
+//Excluded FindTechStacks : QueryBase<TechnologyStack>
 
 // @Route("/favorites/techtacks", "GET")
 public class GetFavoriteTechStack : NSObject, IReturn
@@ -532,22 +440,7 @@ public class UnAssignRoles : NSObject, IReturn
     // @DataMember(Order=3)
     public var roles:[String] = []
 }
-
-// @Route("/posts")
-public class QueryPosts : NSObject, IReturn
-{
-    public typealias Return = QueryResponse<Post>
-    
-    required public override init(){}
-
-    public var skip:Int?
-    public var take:Int?
-    public var orderBy:String?
-    public var orderByDesc:String?
-    public var include:String?
-    public var meta:[String:String] = [:]
-
-}
+//Excluded QueryPosts : QueryBase<Post>
 
 public class LogoUrlApprovalResponse : NSObject
 {
@@ -748,6 +641,9 @@ public class GetUserInfoResponse : NSObject
 public class AuthenticateResponse : NSObject
 {
     required public override init(){}
+    // @DataMember(Order=6)
+    public var responseStatus:ResponseStatus?
+    
     // @DataMember(Order=1)
     public var userId:String?
     
@@ -762,9 +658,6 @@ public class AuthenticateResponse : NSObject
     
     // @DataMember(Order=5)
     public var referrerUrl:String?
-    
-    // @DataMember(Order=6)
-    public var responseStatus:ResponseStatus?
     
     // @DataMember(Order=7)
     public var meta:[String:String] = [:]
@@ -1128,21 +1021,6 @@ extension GetAllTechnologies : JsonSerializable
         ])
 }
 
-extension FindTechnologies : JsonSerializable
-{
-    public static var typeName:String { return "FindTechnologies" }
-    public static var metadata = Metadata.create([
-        Type<FindTechnologies>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-        Type<FindTechnologies>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-        Type<FindTechnologies>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
-        Type<FindTechnologies>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
-        Type<FindTechnologies>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
-        Type<FindTechnologies>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
-        Type<FindTechnologies>.optionalProperty("include", get: { $0.include }, set: { $0.include = $1 }),
-        Type<FindTechnologies>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
-        ])
-}
-
 extension CreateTechnologyStack : JsonSerializable
 {
     public static var typeName:String { return "CreateTechnologyStack" }
@@ -1235,20 +1113,6 @@ extension AppOverview : JsonSerializable
     public static var typeName:String { return "AppOverview" }
     public static var metadata = Metadata.create([
         Type<AppOverview>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-        ])
-}
-
-extension FindTechStacks : JsonSerializable
-{
-    public static var typeName:String { return "FindTechStacks" }
-    public static var metadata = Metadata.create([
-        Type<FindTechStacks>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-        Type<FindTechStacks>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
-        Type<FindTechStacks>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
-        Type<FindTechStacks>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
-        Type<FindTechStacks>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
-        Type<FindTechStacks>.optionalProperty("include", get: { $0.include }, set: { $0.include = $1 }),
-        Type<FindTechStacks>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
         ])
 }
 
@@ -1355,19 +1219,6 @@ extension UnAssignRoles : JsonSerializable
         Type<UnAssignRoles>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
         Type<UnAssignRoles>.arrayProperty("permissions", get: { $0.permissions }, set: { $0.permissions = $1 }),
         Type<UnAssignRoles>.arrayProperty("roles", get: { $0.roles }, set: { $0.roles = $1 }),
-        ])
-}
-
-extension QueryPosts : JsonSerializable
-{
-    public static var typeName:String { return "QueryPosts" }
-    public static var metadata = Metadata.create([
-        Type<QueryPosts>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
-        Type<QueryPosts>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
-        Type<QueryPosts>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
-        Type<QueryPosts>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
-        Type<QueryPosts>.optionalProperty("include", get: { $0.include }, set: { $0.include = $1 }),
-        Type<QueryPosts>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
         ])
 }
 
@@ -1614,12 +1465,12 @@ extension AuthenticateResponse : JsonSerializable
 {
     public static var typeName:String { return "AuthenticateResponse" }
     public static var metadata = Metadata.create([
+        Type<AuthenticateResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
         Type<AuthenticateResponse>.optionalProperty("userId", get: { $0.userId }, set: { $0.userId = $1 }),
         Type<AuthenticateResponse>.optionalProperty("sessionId", get: { $0.sessionId }, set: { $0.sessionId = $1 }),
         Type<AuthenticateResponse>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
         Type<AuthenticateResponse>.optionalProperty("displayName", get: { $0.displayName }, set: { $0.displayName = $1 }),
         Type<AuthenticateResponse>.optionalProperty("referrerUrl", get: { $0.referrerUrl }, set: { $0.referrerUrl = $1 }),
-        Type<AuthenticateResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
         Type<AuthenticateResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
         ])
 }

--- a/src/TechStacks/TechStacks.dtos.swift
+++ b/src/TechStacks/TechStacks.dtos.swift
@@ -1,122 +1,119 @@
 /* Options:
-Date: 2015-02-08 14:56:27
-Version: 1
+Date: 2015-09-25 22:11:55
+SwiftVersion: 2.0
+Version: 4.046
 BaseUrl: http://techstacks.io
 
 BaseClass: NSObject
-//AddResponseStatus: False
 //AddModelExtensions: True
 //AddServiceStackTypes: True
-//InitializeCollections: True
-//AddImplicitVersion:
 //IncludeTypes:
 //ExcludeTypes:
-//DefaultNamespaces: Foundation
+ExcludeGenericBaseTypes: False
+//AddResponseStatus: False
+//AddImplicitVersion:
+//InitializeCollections: True
+//DefaultImports: Foundation
 */
 
-import Foundation
+import Foundation;
 
-public class Technology : TechnologyBase
+// @Route("/admin/technology/{TechnologyId}/logo")
+public class LogoUrlApproval : NSObject, IReturn
 {
-    required public init(){}
-}
-
-public enum TechnologyTier : Int
-{
-    case ProgrammingLanguage
-    case Client
-    case Http
-    case Server
-    case Data
-    case SoftwareInfrastructure
-    case OperatingSystem
-    case HardwareInfrastructure
-    case ThirdPartyServices
-}
-
-// @DataContract
-public class ResponseStatus : NSObject
-{
+    public typealias Return = LogoUrlApprovalResponse
+    
     required public override init(){}
-    // @DataMember(Order=1)
-    public var errorCode:String?
-    
-    // @DataMember(Order=2)
-    public var message:String?
-    
-    // @DataMember(Order=3)
-    public var stackTrace:String?
-    
-    // @DataMember(Order=4)
-    public var errors:[ResponseError] = []
-}
-
-public class TechnologyStack : TechnologyStackBase
-{
-    required public init(){}
-}
-
-public class TechnologyHistory : TechnologyBase
-{
-    required public init(){}
     public var technologyId:Int64?
-    public var operation:String?
+    public var approved:Bool?
 }
 
-public class QueryBase_1<T : JsonSerializable> : QueryBase
+// @Route("/admin/techstacks/{TechnologyStackId}/lock")
+public class LockTechStack : NSObject, IReturn
 {
-    required public init(){}
-}
-
-public class TechStackDetails : TechnologyStackBase
-{
-    required public init(){}
-    public var detailsHtml:String?
-    public var technologyChoices:[TechnologyInStack] = []
-}
-
-public class TechnologyStackHistory : TechnologyStackBase
-{
-    required public init(){}
+    public typealias Return = LockStackResponse
+    
+    required public override init(){}
     public var technologyStackId:Int64?
-    public var operation:String?
-    public var technologyIds:[Int64] = []
+    public var isLocked:Bool?
 }
 
-// @DataContract
-public class Option : NSObject
+// @Route("/admin/technology/{TechnologyId}/lock")
+public class LockTech : NSObject, IReturn
+{
+    public typealias Return = LockStackResponse
+    
+    required public override init(){}
+    public var technologyId:Int64?
+    public var isLocked:Bool?
+}
+
+// @Route("/ping")
+public class Ping : NSObject
 {
     required public override init(){}
-    // @DataMember(Name="name")
-    public var name:String?
-    
-    // @DataMember(Name="title")
-    public var title:String?
-    
-    // @DataMember(Name="value")
-    public var value:TechnologyTier?
 }
 
-public class UserInfo : NSObject
+// @Route("/{PathInfo*}")
+public class FallbackForClientRoutes : NSObject
+{
+    required public override init(){}
+    public var pathInfo:String?
+}
+
+// @Route("/stacks")
+public class ClientAllTechnologyStacks : NSObject
+{
+    required public override init(){}
+}
+
+// @Route("/tech")
+public class ClientAllTechnologies : NSObject
+{
+    required public override init(){}
+}
+
+// @Route("/tech/{Slug}")
+public class ClientTechnology : NSObject
+{
+    required public override init(){}
+    public var slug:String?
+}
+
+// @Route("/users/{UserName}")
+public class ClientUser : NSObject
 {
     required public override init(){}
     public var userName:String?
-    public var avatarUrl:String?
-    public var stacksCount:Int?
 }
 
-public class TechnologyInfo : NSObject
+// @Route("/my-session")
+public class SessionInfo : NSObject
 {
     required public override init(){}
-    public var tier:TechnologyTier?
-    public var slug:String?
-    public var name:String?
-    public var logoUrl:String?
-    public var stacksCount:Int?
 }
 
-public class TechnologyBase : NSObject
+// @Route("/technology", "POST")
+public class CreateTechnology : NSObject, IReturn
 {
+    public typealias Return = CreateTechnologyResponse
+    
+    required public override init(){}
+    public var name:String?
+    public var vendorName:String?
+    public var vendorUrl:String?
+    public var productUrl:String?
+    public var logoUrl:String?
+    public var Description:String?
+    public var isLocked:Bool?
+    public var tier:TechnologyTier?
+}
+
+// @Route("/technology/{Id}", "PUT")
+public class UpdateTechnology : NSObject, IReturn
+{
+    public typealias Return = UpdateTechnologyResponse
+    
     required public override init(){}
     public var id:Int64?
     public var name:String?
@@ -125,74 +122,431 @@ public class TechnologyBase : NSObject
     public var productUrl:String?
     public var logoUrl:String?
     public var Description:String?
-    public var created:NSDate?
-    public var createdBy:String?
-    public var lastModified:NSDate?
-    public var lastModifiedBy:String?
-    public var ownerId:String?
-    public var slug:String?
-    public var logoApproved:Bool?
     public var isLocked:Bool?
     public var tier:TechnologyTier?
-    public var lastStatusUpdate:NSDate?
 }
 
-// @DataContract
-public class ResponseError : NSObject
+// @Route("/technology/{Id}", "DELETE")
+public class DeleteTechnology : NSObject, IReturn
+{
+    public typealias Return = DeleteTechnologyResponse
+    
+    required public override init(){}
+    public var id:Int64?
+}
+
+// @Route("/technology/{Slug}")
+public class GetTechnology : NSObject, IReturn
+{
+    public typealias Return = GetTechnologyResponse
+    
+    required public override init(){}
+    public var reload:Bool?
+    public var slug:String?
+}
+
+// @Route("/technology/{Slug}/previous-versions", "GET")
+public class GetTechnologyPreviousVersions : NSObject, IReturn
+{
+    public typealias Return = GetTechnologyPreviousVersionsResponse
+    
+    required public override init(){}
+    public var slug:String?
+}
+
+// @Route("/technology/{Slug}/favorites")
+public class GetTechnologyFavoriteDetails : NSObject, IReturn
+{
+    public typealias Return = GetTechnologyFavoriteDetailsResponse
+    
+    required public override init(){}
+    public var slug:String?
+    public var reload:Bool?
+}
+
+// @Route("/technology", "GET")
+public class GetAllTechnologies : NSObject, IReturn
+{
+    public typealias Return = GetAllTechnologiesResponse
+    
+    required public override init(){}
+}
+
+//** MJC START
+// @Route("/technology/search")
+// @AutoQueryViewer(Title="Find Technologies", Description="Explore different Technologies", IconUrl="/img/app/tech-white-75.png", DefaultSearchField="Tier", DefaultSearchType="=", DefaultSearchText="Data")
+public class FindTechnologies : NSObject, IReturn
+{
+    //public typealias Return = QueryResponse<Technology>
+    public typealias Return = FindTechnologiesResponse
+    
+    required public override init(){}
+    
+    public var skip:Int?
+    public var take:Int?
+    public var orderBy:String?
+    public var orderByDesc:String?
+    public var include:String?
+    public var meta:[String:String] = [:]
+
+    public var name:String?
+    public var reload:Bool?
+}
+
+public class FindTechnologiesResponse : NSObject
 {
     required public override init(){}
-    // @DataMember(Order=1, EmitDefaultValue=false)
-    public var errorCode:String?
     
-    // @DataMember(Order=2, EmitDefaultValue=false)
-    public var fieldName:String?
-    
-    // @DataMember(Order=3, EmitDefaultValue=false)
-    public var message:String?
+    public var offset:Int?
+    public var total:Int?
+    public var results:[Technology] = []
+    public var meta:[String:String] = [:]
+    public var responseStatus:ResponseStatus?
 }
 
-public class TechnologyStackBase : NSObject
+extension FindTechnologiesResponse : JsonSerializable
 {
+    public static var typeName:String { return "FindTechnologiesResponse" }
+    public static var metadata:Metadata {
+        return Metadata.create([
+            Type<FindTechStacksResponse>.optionalProperty("offset", get: { $0.offset }, set: { $0.offset = $1 }),
+            Type<FindTechStacksResponse>.optionalProperty("total", get: { $0.total }, set: { $0.total = $1 }),
+            Type<FindTechStacksResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+            Type<FindTechStacksResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+            Type<FindTechStacksResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+            ])
+    }
+}
+//** MJC END
+
+
+// @Route("/techstacks", "POST")
+public class CreateTechnologyStack : NSObject, IReturn
+{
+    public typealias Return = CreateTechnologyStackResponse
+    
+    required public override init(){}
+    public var name:String?
+    public var vendorName:String?
+    public var appUrl:String?
+    public var screenshotUrl:String?
+    public var Description:String?
+    public var details:String?
+    public var isLocked:Bool?
+    public var technologyIds:[Int64] = []
+}
+
+// @Route("/techstacks/{Id}", "PUT")
+public class UpdateTechnologyStack : NSObject, IReturn
+{
+    public typealias Return = UpdateTechnologyStackResponse
+    
     required public override init(){}
     public var id:Int64?
     public var name:String?
     public var vendorName:String?
-    public var Description:String?
     public var appUrl:String?
     public var screenshotUrl:String?
-    public var created:NSDate?
-    public var createdBy:String?
-    public var lastModified:NSDate?
-    public var lastModifiedBy:String?
-    public var isLocked:Bool?
-    public var ownerId:String?
-    public var slug:String?
+    public var Description:String?
     public var details:String?
-    public var lastStatusUpdate:NSDate?
+    public var isLocked:Bool?
+    public var technologyIds:[Int64] = []
 }
 
-public class QueryBase : NSObject
+// @Route("/techstacks/{Id}", "DELETE")
+public class DeleteTechnologyStack : NSObject, IReturn
+{
+    public typealias Return = DeleteTechnologyStackResponse
+    
+    required public override init(){}
+    public var id:Int64?
+}
+
+// @Route("/techstacks", "GET")
+public class GetAllTechnologyStacks : NSObject, IReturn
+{
+    public typealias Return = GetAllTechnologyStacksResponse
+    
+    required public override init(){}
+}
+
+// @Route("/techstacks/{Slug}", "GET")
+public class GetTechnologyStack : NSObject, IReturn
+{
+    public typealias Return = GetTechnologyStackResponse
+    
+    required public override init(){}
+    public var reload:Bool?
+    public var slug:String?
+}
+
+// @Route("/techstacks/{Slug}/previous-versions", "GET")
+public class GetTechnologyStackPreviousVersions : NSObject, IReturn
+{
+    public typealias Return = GetTechnologyStackPreviousVersionsResponse
+    
+    required public override init(){}
+    public var slug:String?
+}
+
+// @Route("/techstacks/{Slug}/favorites")
+public class GetTechnologyStackFavoriteDetails : NSObject, IReturn
+{
+    public typealias Return = GetTechnologyStackFavoriteDetailsResponse
+    
+    required public override init(){}
+    public var slug:String?
+    public var reload:Bool?
+}
+
+// @Route("/config")
+public class GetConfig : NSObject, IReturn
+{
+    public typealias Return = GetConfigResponse
+    
+    required public override init(){}
+}
+
+// @Route("/overview")
+public class Overview : NSObject, IReturn
+{
+    public typealias Return = OverviewResponse
+    
+    required public override init(){}
+    public var reload:Bool?
+}
+
+// @Route("/app-overview")
+public class AppOverview : NSObject, IReturn
+{
+    public typealias Return = AppOverviewResponse
+    
+    required public override init(){}
+    public var reload:Bool?
+}
+
+//** MJC START
+// @Route("/techstacks/search")
+// @AutoQueryViewer(Title="Find Technology Stacks", Description="Explore different Technology Stacks", IconUrl="/img/app/stacks-white-75.png", DefaultSearchField="Description", DefaultSearchType="Contains", DefaultSearchText="ServiceStack")
+public class FindTechStacks : NSObject, IReturn
+{
+    //public typealias Return = QueryResponse<TechnologyStack>
+    public typealias Return = FindTechStacksResponse
+    
+    required public override init(){}
+    
+    public var skip:Int?
+    public var take:Int?
+    public var orderBy:String?
+    public var orderByDesc:String?
+    public var include:String?
+    public var meta:[String:String] = [:]
+    
+    public var reload:Bool?
+}
+
+public class FindTechStacksResponse : NSObject
 {
     required public override init(){}
-    // @DataMember(Order=1)
-    public var skip:Int?
     
-    // @DataMember(Order=2)
-    public var take:Int?
-    
-    // @DataMember(Order=3)
-    public var orderBy:String?
-    
-    // @DataMember(Order=4)
-    public var orderByDesc:String?
+    public var offset:Int?
+    public var total:Int?
+    public var results:[TechnologyStack] = []
+    public var meta:[String:String] = [:]
+    public var responseStatus:ResponseStatus?
 }
 
-public class TechnologyInStack : TechnologyBase
+extension FindTechStacksResponse : JsonSerializable
 {
-    required public init(){}
-    public var technologyId:Int64?
-    public var technologyStackId:Int64?
-    public var justification:String?
+    public static var typeName:String { return "FindTechStacksResponse" }
+    public static var metadata:Metadata {
+        return Metadata.create([
+            Type<FindTechStacksResponse>.optionalProperty("offset", get: { $0.offset }, set: { $0.offset = $1 }),
+            Type<FindTechStacksResponse>.optionalProperty("total", get: { $0.total }, set: { $0.total = $1 }),
+            Type<FindTechStacksResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+            Type<FindTechStacksResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+            Type<FindTechStacksResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+            ])
+    }
+}
+//** MJC END
+
+// @Route("/favorites/techtacks", "GET")
+public class GetFavoriteTechStack : NSObject, IReturn
+{
+    public typealias Return = GetFavoriteTechStackResponse
+    
+    required public override init(){}
+    public var technologyStackId:Int?
+}
+
+// @Route("/favorites/techtacks/{TechnologyStackId}", "PUT")
+public class AddFavoriteTechStack : NSObject, IReturn
+{
+    public typealias Return = FavoriteTechStackResponse
+    
+    required public override init(){}
+    public var technologyStackId:Int?
+}
+
+// @Route("/favorites/techtacks/{TechnologyStackId}", "DELETE")
+public class RemoveFavoriteTechStack : NSObject, IReturn
+{
+    public typealias Return = FavoriteTechStackResponse
+    
+    required public override init(){}
+    public var technologyStackId:Int?
+}
+
+// @Route("/favorites/technology", "GET")
+public class GetFavoriteTechnologies : NSObject, IReturn
+{
+    public typealias Return = GetFavoriteTechnologiesResponse
+    
+    required public override init(){}
+    public var technologyId:Int?
+}
+
+// @Route("/favorites/technology/{TechnologyId}", "PUT")
+public class AddFavoriteTechnology : NSObject, IReturn
+{
+    public typealias Return = FavoriteTechnologyResponse
+    
+    required public override init(){}
+    public var technologyId:Int?
+}
+
+// @Route("/favorites/technology/{TechnologyId}", "DELETE")
+public class RemoveFavoriteTechnology : NSObject, IReturn
+{
+    public typealias Return = FavoriteTechnologyResponse
+    
+    required public override init(){}
+    public var technologyId:Int?
+}
+
+// @Route("/my-feed")
+public class GetUserFeed : NSObject, IReturn
+{
+    public typealias Return = GetUserFeedResponse
+    
+    required public override init(){}
+}
+
+// @Route("/userinfo/{UserName}")
+public class GetUserInfo : NSObject, IReturn
+{
+    public typealias Return = GetUserInfoResponse
+    
+    required public override init(){}
+    public var reload:Bool?
+    public var userName:String?
+}
+
+// @Route("/auth")
+// @Route("/auth/{provider}")
+// @Route("/authenticate")
+// @Route("/authenticate/{provider}")
+// @DataContract
+public class Authenticate : NSObject, IReturn
+{
+    public typealias Return = AuthenticateResponse
+    
+    required public override init(){}
+    // @DataMember(Order=1)
+    public var provider:String?
+    
+    // @DataMember(Order=2)
+    public var state:String?
+    
+    // @DataMember(Order=3)
+    public var oauth_token:String?
+    
+    // @DataMember(Order=4)
+    public var oauth_verifier:String?
+    
+    // @DataMember(Order=5)
+    public var userName:String?
+    
+    // @DataMember(Order=6)
+    public var password:String?
+    
+    // @DataMember(Order=7)
+    public var rememberMe:Bool?
+    
+    // @DataMember(Order=8)
+    public var `continue`:String?
+    
+    // @DataMember(Order=9)
+    public var nonce:String?
+    
+    // @DataMember(Order=10)
+    public var uri:String?
+    
+    // @DataMember(Order=11)
+    public var response:String?
+    
+    // @DataMember(Order=12)
+    public var qop:String?
+    
+    // @DataMember(Order=13)
+    public var nc:String?
+    
+    // @DataMember(Order=14)
+    public var cnonce:String?
+    
+    // @DataMember(Order=15)
+    public var meta:[String:String] = [:]
+}
+
+// @Route("/assignroles")
+// @DataContract
+public class AssignRoles : NSObject, IReturn
+{
+    public typealias Return = AssignRolesResponse
+    
+    required public override init(){}
+    // @DataMember(Order=1)
+    public var userName:String?
+    
+    // @DataMember(Order=2)
+    public var permissions:[String] = []
+    
+    // @DataMember(Order=3)
+    public var roles:[String] = []
+}
+
+// @Route("/unassignroles")
+// @DataContract
+public class UnAssignRoles : NSObject, IReturn
+{
+    public typealias Return = UnAssignRolesResponse
+    
+    required public override init(){}
+    // @DataMember(Order=1)
+    public var userName:String?
+    
+    // @DataMember(Order=2)
+    public var permissions:[String] = []
+    
+    // @DataMember(Order=3)
+    public var roles:[String] = []
+}
+
+// @Route("/posts")
+public class QueryPosts : NSObject, IReturn
+{
+    public typealias Return = QueryResponse<Post>
+    
+    required public override init(){}
+
+    public var skip:Int?
+    public var take:Int?
+    public var orderBy:String?
+    public var orderByDesc:String?
+    public var include:String?
+    public var meta:[String:String] = [:]
+
 }
 
 public class LogoUrlApprovalResponse : NSObject
@@ -256,7 +610,7 @@ public class GetAllTechnologiesResponse : NSObject
 }
 
 // @DataContract
-public class QueryResponse<Technology : JsonSerializable> : NSObject
+public class QueryResponse<T : JsonSerializable> : NSObject
 {
     required public override init(){}
     // @DataMember(Order=1)
@@ -266,7 +620,7 @@ public class QueryResponse<Technology : JsonSerializable> : NSObject
     public var total:Int?
     
     // @DataMember(Order=3)
-    public var results:[Technology] = []
+    public var results:[T] = []
     
     // @DataMember(Order=4)
     public var meta:[String:String] = [:]
@@ -416,491 +770,902 @@ public class AuthenticateResponse : NSObject
     public var meta:[String:String] = [:]
 }
 
+// @DataContract
 public class AssignRolesResponse : NSObject
 {
     required public override init(){}
+    // @DataMember(Order=1)
     public var allRoles:[String] = []
+    
+    // @DataMember(Order=2)
     public var allPermissions:[String] = []
+    
+    // @DataMember(Order=3)
     public var responseStatus:ResponseStatus?
 }
 
+// @DataContract
 public class UnAssignRolesResponse : NSObject
 {
     required public override init(){}
+    // @DataMember(Order=1)
     public var allRoles:[String] = []
+    
+    // @DataMember(Order=2)
     public var allPermissions:[String] = []
+    
+    // @DataMember(Order=3)
     public var responseStatus:ResponseStatus?
 }
 
-// @Route("/admin/technology/{TechnologyId}/logo")
-public class LogoUrlApproval : NSObject, IReturn
+public class Technology : TechnologyBase
 {
-    typealias Return = LogoUrlApprovalResponse
-    
-    required public override init(){}
-    public var technologyId:Int64?
-    public var approved:Bool?
+    required public init(){}
 }
 
-// @Route("/admin/techstacks/{TechnologyStackId}/lock")
-public class LockTechStack : NSObject, IReturn
+public enum TechnologyTier : Int
 {
-    typealias Return = LockStackResponse
-    
-    required public override init(){}
+    case ProgrammingLanguage
+    case Client
+    case Http
+    case Server
+    case Data
+    case SoftwareInfrastructure
+    case OperatingSystem
+    case HardwareInfrastructure
+    case ThirdPartyServices
+}
+
+public class TechnologyStack : TechnologyStackBase
+{
+    required public init(){}
+}
+
+public class TechnologyHistory : TechnologyBase
+{
+    required public init(){}
+    public var technologyId:Int64?
+    public var operation:String?
+}
+
+public class QueryBase_1<T : JsonSerializable> : QueryBase
+{
+    required public init(){}
+}
+
+public class TechStackDetails : TechnologyStackBase
+{
+    required public init(){}
+    public var detailsHtml:String?
+    public var technologyChoices:[TechnologyInStack] = []
+}
+
+public class TechnologyStackHistory : TechnologyStackBase
+{
+    required public init(){}
     public var technologyStackId:Int64?
-    public var isLocked:Bool?
-}
-
-// @Route("/admin/technology/{TechnologyId}/lock")
-public class LockTech : NSObject, IReturn
-{
-    typealias Return = LockStackResponse
-    
-    required public override init(){}
-    public var technologyId:Int64?
-    public var isLocked:Bool?
-}
-
-// @Route("/ping")
-public class Ping : NSObject
-{
-    required public override init(){}
-}
-
-// @Route("/{PathInfo*}")
-public class FallbackForClientRoutes : NSObject
-{
-    required public override init(){}
-    public var pathInfo:String?
-}
-
-// @Route("/stacks")
-public class ClientAllTechnologyStacks : NSObject
-{
-    required public override init(){}
-}
-
-// @Route("/tech")
-public class ClientAllTechnologies : NSObject
-{
-    required public override init(){}
-}
-
-// @Route("/tech/{Slug}")
-public class ClientTechnology : NSObject
-{
-    required public override init(){}
-    public var slug:String?
-}
-
-// @Route("/users/{UserName}")
-public class ClientUser : NSObject
-{
-    required public override init(){}
-    public var userName:String?
-}
-
-// @Route("/my-session")
-public class SessionInfo : NSObject
-{
-    required public override init(){}
-}
-
-// @Route("/technology", "POST")
-public class CreateTechnology : NSObject, IReturn
-{
-    typealias Return = CreateTechnologyResponse
-    
-    required public override init(){}
-    public var name:String?
-    public var vendorName:String?
-    public var vendorUrl:String?
-    public var productUrl:String?
-    public var logoUrl:String?
-    public var Description:String?
-    public var isLocked:Bool?
-    public var tier:TechnologyTier?
-}
-
-// @Route("/technology/{Id}", "PUT")
-public class UpdateTechnology : NSObject, IReturn
-{
-    typealias Return = UpdateTechnologyResponse
-    
-    required public override init(){}
-    public var id:Int64?
-    public var name:String?
-    public var vendorName:String?
-    public var vendorUrl:String?
-    public var productUrl:String?
-    public var logoUrl:String?
-    public var Description:String?
-    public var isLocked:Bool?
-    public var tier:TechnologyTier?
-}
-
-// @Route("/technology/{Id}", "DELETE")
-public class DeleteTechnology : NSObject, IReturn
-{
-    typealias Return = DeleteTechnologyResponse
-    
-    required public override init(){}
-    public var id:Int64?
-}
-
-// @Route("/technology/{Slug}")
-public class GetTechnology : NSObject, IReturn
-{
-    typealias Return = GetTechnologyResponse
-    
-    required public override init(){}
-    public var reload:Bool?
-    public var slug:String?
-}
-
-// @Route("/technology/{Slug}/previous-versions", "GET")
-public class GetTechnologyPreviousVersions : NSObject, IReturn
-{
-    typealias Return = GetTechnologyPreviousVersionsResponse
-    
-    required public override init(){}
-    public var slug:String?
-}
-
-// @Route("/technology/{Slug}/favorites")
-public class GetTechnologyFavoriteDetails : NSObject, IReturn
-{
-    typealias Return = GetTechnologyFavoriteDetailsResponse
-    
-    required public override init(){}
-    public var slug:String?
-    public var reload:Bool?
-}
-
-// @Route("/technology", "GET")
-public class GetAllTechnologies : NSObject, IReturn
-{
-    typealias Return = GetAllTechnologiesResponse
-    
-    required public override init(){}
-}
-
-// @Route("/technology/search")
-public class FindTechnologies<Technology : JsonSerializable> : QueryBase_1<Technology>, IReturn
-{
-    typealias Return = QueryResponse<Technology>
-    
-    required public init(){}
-    public var name:String?
-    public var reload:Bool?
-}
-
-// @Route("/techstacks", "POST")
-public class CreateTechnologyStack : NSObject, IReturn
-{
-    typealias Return = CreateTechnologyStackResponse
-    
-    required public override init(){}
-    public var name:String?
-    public var vendorName:String?
-    public var appUrl:String?
-    public var screenshotUrl:String?
-    public var Description:String?
-    public var details:String?
-    public var isLocked:Bool?
+    public var operation:String?
     public var technologyIds:[Int64] = []
 }
 
-// @Route("/techstacks/{Id}", "PUT")
-public class UpdateTechnologyStack : NSObject, IReturn
-{
-    typealias Return = UpdateTechnologyStackResponse
-    
-    required public override init(){}
-    public var id:Int64?
-    public var name:String?
-    public var vendorName:String?
-    public var appUrl:String?
-    public var screenshotUrl:String?
-    public var Description:String?
-    public var details:String?
-    public var isLocked:Bool?
-    public var technologyIds:[Int64] = []
-}
-
-// @Route("/techstacks/{Id}", "DELETE")
-public class DeleteTechnologyStack : NSObject, IReturn
-{
-    typealias Return = DeleteTechnologyStackResponse
-    
-    required public override init(){}
-    public var id:Int64?
-}
-
-// @Route("/techstacks", "GET")
-public class GetAllTechnologyStacks : NSObject, IReturn
-{
-    typealias Return = GetAllTechnologyStacksResponse
-    
-    required public override init(){}
-}
-
-// @Route("/techstacks/{Slug}", "GET")
-public class GetTechnologyStack : NSObject, IReturn
-{
-    typealias Return = GetTechnologyStackResponse
-    
-    required public override init(){}
-    public var reload:Bool?
-    public var slug:String?
-}
-
-// @Route("/techstacks/{Slug}/previous-versions", "GET")
-public class GetTechnologyStackPreviousVersions : NSObject, IReturn
-{
-    typealias Return = GetTechnologyStackPreviousVersionsResponse
-    
-    required public override init(){}
-    public var slug:String?
-}
-
-// @Route("/techstacks/{Slug}/favorites")
-public class GetTechnologyStackFavoriteDetails : NSObject, IReturn
-{
-    typealias Return = GetTechnologyStackFavoriteDetailsResponse
-    
-    required public override init(){}
-    public var slug:String?
-    public var reload:Bool?
-}
-
-// @Route("/config")
-public class GetConfig : NSObject, IReturn
-{
-    typealias Return = GetConfigResponse
-    
-    required public override init(){}
-}
-
-// @Route("/overview")
-public class Overview : NSObject, IReturn
-{
-    typealias Return = OverviewResponse
-    
-    required public override init(){}
-    public var reload:Bool?
-}
-
-// @Route("/app-overview")
-public class AppOverview : NSObject, IReturn
-{
-    typealias Return = AppOverviewResponse
-    
-    required public override init(){}
-    public var reload:Bool?
-}
-
-// @Route("/techstacks/search")
-public class FindTechStacks<TechnologyStack : JsonSerializable> : QueryBase_1<TechnologyStack>, IReturn
-{
-    typealias Return = QueryResponse<TechnologyStack>
-    
-    required public init(){}
-    public var reload:Bool?
-}
-
-// @Route("/favorites/techtacks", "GET")
-public class GetFavoriteTechStack : NSObject, IReturn
-{
-    typealias Return = GetFavoriteTechStackResponse
-    
-    required public override init(){}
-    public var technologyStackId:Int?
-}
-
-// @Route("/favorites/techtacks/{TechnologyStackId}", "PUT")
-public class AddFavoriteTechStack : NSObject, IReturn
-{
-    typealias Return = FavoriteTechStackResponse
-    
-    required public override init(){}
-    public var technologyStackId:Int?
-}
-
-// @Route("/favorites/techtacks/{TechnologyStackId}", "DELETE")
-public class RemoveFavoriteTechStack : NSObject, IReturn
-{
-    typealias Return = FavoriteTechStackResponse
-    
-    required public override init(){}
-    public var technologyStackId:Int?
-}
-
-// @Route("/favorites/technology", "GET")
-public class GetFavoriteTechnologies : NSObject, IReturn
-{
-    typealias Return = GetFavoriteTechnologiesResponse
-    
-    required public override init(){}
-    public var technologyId:Int?
-}
-
-// @Route("/favorites/technology/{TechnologyId}", "PUT")
-public class AddFavoriteTechnology : NSObject, IReturn
-{
-    typealias Return = FavoriteTechnologyResponse
-    
-    required public override init(){}
-    public var technologyId:Int?
-}
-
-// @Route("/favorites/technology/{TechnologyId}", "DELETE")
-public class RemoveFavoriteTechnology : NSObject, IReturn
-{
-    typealias Return = FavoriteTechnologyResponse
-    
-    required public override init(){}
-    public var technologyId:Int?
-}
-
-// @Route("/my-feed")
-public class GetUserFeed : NSObject, IReturn
-{
-    typealias Return = GetUserFeedResponse
-    
-    required public override init(){}
-}
-
-// @Route("/userinfo/{UserName}")
-public class GetUserInfo : NSObject, IReturn
-{
-    typealias Return = GetUserInfoResponse
-    
-    required public override init(){}
-    public var reload:Bool?
-    public var userName:String?
-}
-
-// @Route("/auth")
-// @Route("/auth/{provider}")
-// @Route("/authenticate")
-// @Route("/authenticate/{provider}")
 // @DataContract
-public class Authenticate : NSObject, IReturn
+public class Option : NSObject
 {
-    typealias Return = AuthenticateResponse
+    required public override init(){}
+    // @DataMember(Name="name")
+    public var name:String?
     
+    // @DataMember(Name="title")
+    public var title:String?
+    
+    // @DataMember(Name="value")
+    public var value:TechnologyTier?
+}
+
+public class UserInfo : NSObject
+{
+    required public override init(){}
+    public var userName:String?
+    public var avatarUrl:String?
+    public var stacksCount:Int?
+}
+
+public class TechnologyInfo : NSObject
+{
+    required public override init(){}
+    public var tier:TechnologyTier?
+    public var slug:String?
+    public var name:String?
+    public var logoUrl:String?
+    public var stacksCount:Int?
+}
+
+public class Post : NSObject
+{
+    required public override init(){}
+    public var id:Int?
+    public var userId:String?
+    public var userName:String?
+    public var date:String?
+    public var shortDate:String?
+    public var textHtml:String?
+    public var comments:[PostComment] = []
+}
+
+public class TechnologyBase : NSObject
+{
+    required public override init(){}
+    public var id:Int64?
+    public var name:String?
+    public var vendorName:String?
+    public var vendorUrl:String?
+    public var productUrl:String?
+    public var logoUrl:String?
+    public var Description:String?
+    public var created:NSDate?
+    public var createdBy:String?
+    public var lastModified:NSDate?
+    public var lastModifiedBy:String?
+    public var ownerId:String?
+    public var slug:String?
+    public var logoApproved:Bool?
+    public var isLocked:Bool?
+    public var tier:TechnologyTier?
+    public var lastStatusUpdate:NSDate?
+}
+
+public class TechnologyStackBase : NSObject
+{
+    required public override init(){}
+    public var id:Int64?
+    public var name:String?
+    public var vendorName:String?
+    public var Description:String?
+    public var appUrl:String?
+    public var screenshotUrl:String?
+    public var created:NSDate?
+    public var createdBy:String?
+    public var lastModified:NSDate?
+    public var lastModifiedBy:String?
+    public var isLocked:Bool?
+    public var ownerId:String?
+    public var slug:String?
+    public var details:String?
+    public var lastStatusUpdate:NSDate?
+}
+
+public class QueryBase : NSObject
+{
     required public override init(){}
     // @DataMember(Order=1)
-    public var provider:String?
+    public var skip:Int?
     
     // @DataMember(Order=2)
-    public var state:String?
+    public var take:Int?
     
     // @DataMember(Order=3)
-    public var oauth_token:String?
+    public var orderBy:String?
     
     // @DataMember(Order=4)
-    public var oauth_verifier:String?
+    public var orderByDesc:String?
     
     // @DataMember(Order=5)
-    public var userName:String?
+    public var include:String?
     
     // @DataMember(Order=6)
-    public var password:String?
-    
-    // @DataMember(Order=7)
-    public var rememberMe:Bool?
-    
-    // @DataMember(Order=8)
-    public var Continue:String?
-    
-    // @DataMember(Order=9)
-    public var nonce:String?
-    
-    // @DataMember(Order=10)
-    public var uri:String?
-    
-    // @DataMember(Order=11)
-    public var response:String?
-    
-    // @DataMember(Order=12)
-    public var qop:String?
-    
-    // @DataMember(Order=13)
-    public var nc:String?
-    
-    // @DataMember(Order=14)
-    public var cnonce:String?
-    
-    // @DataMember(Order=15)
     public var meta:[String:String] = [:]
 }
 
-// @Route("/assignroles")
-public class AssignRoles : NSObject, IReturn
+public class TechnologyInStack : TechnologyBase
 {
-    typealias Return = AssignRolesResponse
-    
-    required public override init(){}
-    public var userName:String?
-    public var permissions:[String] = []
-    public var roles:[String] = []
+    required public init(){}
+    public var technologyId:Int64?
+    public var technologyStackId:Int64?
+    public var justification:String?
 }
 
-// @Route("/unassignroles")
-public class UnAssignRoles : NSObject, IReturn
+public class PostComment : NSObject
 {
-    typealias Return = UnAssignRolesResponse
-    
     required public override init(){}
+    public var id:Int?
+    public var postId:Int?
+    public var userId:String?
     public var userName:String?
-    public var permissions:[String] = []
-    public var roles:[String] = []
+    public var date:String?
+    public var shortDate:String?
+    public var textHtml:String?
 }
 
+
+extension LogoUrlApproval : JsonSerializable
+{
+    public static var typeName:String { return "LogoUrlApproval" }
+    public static var metadata = Metadata.create([
+        Type<LogoUrlApproval>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
+        Type<LogoUrlApproval>.optionalProperty("approved", get: { $0.approved }, set: { $0.approved = $1 }),
+        ])
+}
+
+extension LockTechStack : JsonSerializable
+{
+    public static var typeName:String { return "LockTechStack" }
+    public static var metadata = Metadata.create([
+        Type<LockTechStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
+        Type<LockTechStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        ])
+}
+
+extension LockTech : JsonSerializable
+{
+    public static var typeName:String { return "LockTech" }
+    public static var metadata = Metadata.create([
+        Type<LockTech>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
+        Type<LockTech>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        ])
+}
+
+extension Ping : JsonSerializable
+{
+    public static var typeName:String { return "Ping" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension FallbackForClientRoutes : JsonSerializable
+{
+    public static var typeName:String { return "FallbackForClientRoutes" }
+    public static var metadata = Metadata.create([
+        Type<FallbackForClientRoutes>.optionalProperty("pathInfo", get: { $0.pathInfo }, set: { $0.pathInfo = $1 }),
+        ])
+}
+
+extension ClientAllTechnologyStacks : JsonSerializable
+{
+    public static var typeName:String { return "ClientAllTechnologyStacks" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension ClientAllTechnologies : JsonSerializable
+{
+    public static var typeName:String { return "ClientAllTechnologies" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension ClientTechnology : JsonSerializable
+{
+    public static var typeName:String { return "ClientTechnology" }
+    public static var metadata = Metadata.create([
+        Type<ClientTechnology>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        ])
+}
+
+extension ClientUser : JsonSerializable
+{
+    public static var typeName:String { return "ClientUser" }
+    public static var metadata = Metadata.create([
+        Type<ClientUser>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        ])
+}
+
+extension SessionInfo : JsonSerializable
+{
+    public static var typeName:String { return "SessionInfo" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension CreateTechnology : JsonSerializable
+{
+    public static var typeName:String { return "CreateTechnology" }
+    public static var metadata = Metadata.create([
+        Type<CreateTechnology>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<CreateTechnology>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<CreateTechnology>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
+        Type<CreateTechnology>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
+        Type<CreateTechnology>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
+        Type<CreateTechnology>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<CreateTechnology>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<CreateTechnology>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
+        ])
+}
+
+extension UpdateTechnology : JsonSerializable
+{
+    public static var typeName:String { return "UpdateTechnology" }
+    public static var metadata = Metadata.create([
+        Type<UpdateTechnology>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<UpdateTechnology>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<UpdateTechnology>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<UpdateTechnology>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
+        Type<UpdateTechnology>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
+        Type<UpdateTechnology>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
+        Type<UpdateTechnology>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<UpdateTechnology>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<UpdateTechnology>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
+        ])
+}
+
+extension DeleteTechnology : JsonSerializable
+{
+    public static var typeName:String { return "DeleteTechnology" }
+    public static var metadata = Metadata.create([
+        Type<DeleteTechnology>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        ])
+}
+
+extension GetTechnology : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnology" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnology>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        Type<GetTechnology>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        ])
+}
+
+extension GetTechnologyPreviousVersions : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyPreviousVersions" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyPreviousVersions>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        ])
+}
+
+extension GetTechnologyFavoriteDetails : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyFavoriteDetails" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyFavoriteDetails>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<GetTechnologyFavoriteDetails>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        ])
+}
+
+extension GetAllTechnologies : JsonSerializable
+{
+    public static var typeName:String { return "GetAllTechnologies" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension FindTechnologies : JsonSerializable
+{
+    public static var typeName:String { return "FindTechnologies" }
+    public static var metadata = Metadata.create([
+        Type<FindTechnologies>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<FindTechnologies>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        Type<FindTechnologies>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
+        Type<FindTechnologies>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
+        Type<FindTechnologies>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
+        Type<FindTechnologies>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
+        Type<FindTechnologies>.optionalProperty("include", get: { $0.include }, set: { $0.include = $1 }),
+        Type<FindTechnologies>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+extension CreateTechnologyStack : JsonSerializable
+{
+    public static var typeName:String { return "CreateTechnologyStack" }
+    public static var metadata = Metadata.create([
+        Type<CreateTechnologyStack>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<CreateTechnologyStack>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<CreateTechnologyStack>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
+        Type<CreateTechnologyStack>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
+        Type<CreateTechnologyStack>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<CreateTechnologyStack>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
+        Type<CreateTechnologyStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<CreateTechnologyStack>.arrayProperty("technologyIds", get: { $0.technologyIds }, set: { $0.technologyIds = $1 }),
+        ])
+}
+
+extension UpdateTechnologyStack : JsonSerializable
+{
+    public static var typeName:String { return "UpdateTechnologyStack" }
+    public static var metadata = Metadata.create([
+        Type<UpdateTechnologyStack>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<UpdateTechnologyStack>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<UpdateTechnologyStack>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<UpdateTechnologyStack>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
+        Type<UpdateTechnologyStack>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
+        Type<UpdateTechnologyStack>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<UpdateTechnologyStack>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
+        Type<UpdateTechnologyStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<UpdateTechnologyStack>.arrayProperty("technologyIds", get: { $0.technologyIds }, set: { $0.technologyIds = $1 }),
+        ])
+}
+
+extension DeleteTechnologyStack : JsonSerializable
+{
+    public static var typeName:String { return "DeleteTechnologyStack" }
+    public static var metadata = Metadata.create([
+        Type<DeleteTechnologyStack>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        ])
+}
+
+extension GetAllTechnologyStacks : JsonSerializable
+{
+    public static var typeName:String { return "GetAllTechnologyStacks" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension GetTechnologyStack : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyStack" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyStack>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        Type<GetTechnologyStack>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        ])
+}
+
+extension GetTechnologyStackPreviousVersions : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyStackPreviousVersions" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyStackPreviousVersions>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        ])
+}
+
+extension GetTechnologyStackFavoriteDetails : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyStackFavoriteDetails" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyStackFavoriteDetails>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<GetTechnologyStackFavoriteDetails>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        ])
+}
+
+extension GetConfig : JsonSerializable
+{
+    public static var typeName:String { return "GetConfig" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension Overview : JsonSerializable
+{
+    public static var typeName:String { return "Overview" }
+    public static var metadata = Metadata.create([
+        Type<Overview>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        ])
+}
+
+extension AppOverview : JsonSerializable
+{
+    public static var typeName:String { return "AppOverview" }
+    public static var metadata = Metadata.create([
+        Type<AppOverview>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        ])
+}
+
+extension FindTechStacks : JsonSerializable
+{
+    public static var typeName:String { return "FindTechStacks" }
+    public static var metadata = Metadata.create([
+        Type<FindTechStacks>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        Type<FindTechStacks>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
+        Type<FindTechStacks>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
+        Type<FindTechStacks>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
+        Type<FindTechStacks>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
+        Type<FindTechStacks>.optionalProperty("include", get: { $0.include }, set: { $0.include = $1 }),
+        Type<FindTechStacks>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+extension GetFavoriteTechStack : JsonSerializable
+{
+    public static var typeName:String { return "GetFavoriteTechStack" }
+    public static var metadata = Metadata.create([
+        Type<GetFavoriteTechStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
+        ])
+}
+
+extension AddFavoriteTechStack : JsonSerializable
+{
+    public static var typeName:String { return "AddFavoriteTechStack" }
+    public static var metadata = Metadata.create([
+        Type<AddFavoriteTechStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
+        ])
+}
+
+extension RemoveFavoriteTechStack : JsonSerializable
+{
+    public static var typeName:String { return "RemoveFavoriteTechStack" }
+    public static var metadata = Metadata.create([
+        Type<RemoveFavoriteTechStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
+        ])
+}
+
+extension GetFavoriteTechnologies : JsonSerializable
+{
+    public static var typeName:String { return "GetFavoriteTechnologies" }
+    public static var metadata = Metadata.create([
+        Type<GetFavoriteTechnologies>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
+        ])
+}
+
+extension AddFavoriteTechnology : JsonSerializable
+{
+    public static var typeName:String { return "AddFavoriteTechnology" }
+    public static var metadata = Metadata.create([
+        Type<AddFavoriteTechnology>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
+        ])
+}
+
+extension RemoveFavoriteTechnology : JsonSerializable
+{
+    public static var typeName:String { return "RemoveFavoriteTechnology" }
+    public static var metadata = Metadata.create([
+        Type<RemoveFavoriteTechnology>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
+        ])
+}
+
+extension GetUserFeed : JsonSerializable
+{
+    public static var typeName:String { return "GetUserFeed" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension GetUserInfo : JsonSerializable
+{
+    public static var typeName:String { return "GetUserInfo" }
+    public static var metadata = Metadata.create([
+        Type<GetUserInfo>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
+        Type<GetUserInfo>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        ])
+}
+
+extension Authenticate : JsonSerializable
+{
+    public static var typeName:String { return "Authenticate" }
+    public static var metadata = Metadata.create([
+        Type<Authenticate>.optionalProperty("provider", get: { $0.provider }, set: { $0.provider = $1 }),
+        Type<Authenticate>.optionalProperty("state", get: { $0.state }, set: { $0.state = $1 }),
+        Type<Authenticate>.optionalProperty("oauth_token", get: { $0.oauth_token }, set: { $0.oauth_token = $1 }),
+        Type<Authenticate>.optionalProperty("oauth_verifier", get: { $0.oauth_verifier }, set: { $0.oauth_verifier = $1 }),
+        Type<Authenticate>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        Type<Authenticate>.optionalProperty("password", get: { $0.password }, set: { $0.password = $1 }),
+        Type<Authenticate>.optionalProperty("rememberMe", get: { $0.rememberMe }, set: { $0.rememberMe = $1 }),
+        Type<Authenticate>.optionalProperty("`continue`", get: { $0.`continue` }, set: { $0.`continue` = $1 }),
+        Type<Authenticate>.optionalProperty("nonce", get: { $0.nonce }, set: { $0.nonce = $1 }),
+        Type<Authenticate>.optionalProperty("uri", get: { $0.uri }, set: { $0.uri = $1 }),
+        Type<Authenticate>.optionalProperty("response", get: { $0.response }, set: { $0.response = $1 }),
+        Type<Authenticate>.optionalProperty("qop", get: { $0.qop }, set: { $0.qop = $1 }),
+        Type<Authenticate>.optionalProperty("nc", get: { $0.nc }, set: { $0.nc = $1 }),
+        Type<Authenticate>.optionalProperty("cnonce", get: { $0.cnonce }, set: { $0.cnonce = $1 }),
+        Type<Authenticate>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+extension AssignRoles : JsonSerializable
+{
+    public static var typeName:String { return "AssignRoles" }
+    public static var metadata = Metadata.create([
+        Type<AssignRoles>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        Type<AssignRoles>.arrayProperty("permissions", get: { $0.permissions }, set: { $0.permissions = $1 }),
+        Type<AssignRoles>.arrayProperty("roles", get: { $0.roles }, set: { $0.roles = $1 }),
+        ])
+}
+
+extension UnAssignRoles : JsonSerializable
+{
+    public static var typeName:String { return "UnAssignRoles" }
+    public static var metadata = Metadata.create([
+        Type<UnAssignRoles>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        Type<UnAssignRoles>.arrayProperty("permissions", get: { $0.permissions }, set: { $0.permissions = $1 }),
+        Type<UnAssignRoles>.arrayProperty("roles", get: { $0.roles }, set: { $0.roles = $1 }),
+        ])
+}
+
+extension QueryPosts : JsonSerializable
+{
+    public static var typeName:String { return "QueryPosts" }
+    public static var metadata = Metadata.create([
+        Type<QueryPosts>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
+        Type<QueryPosts>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
+        Type<QueryPosts>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
+        Type<QueryPosts>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
+        Type<QueryPosts>.optionalProperty("include", get: { $0.include }, set: { $0.include = $1 }),
+        Type<QueryPosts>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+extension LogoUrlApprovalResponse : JsonSerializable
+{
+    public static var typeName:String { return "LogoUrlApprovalResponse" }
+    public static var metadata = Metadata.create([
+        Type<LogoUrlApprovalResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        ])
+}
+
+extension LockStackResponse : JsonSerializable
+{
+    public static var typeName:String { return "LockStackResponse" }
+    public static var metadata = Metadata.create([
+        ])
+}
+
+extension CreateTechnologyResponse : JsonSerializable
+{
+    public static var typeName:String { return "CreateTechnologyResponse" }
+    public static var metadata = Metadata.create([
+        Type<CreateTechnologyResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        Type<CreateTechnologyResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension UpdateTechnologyResponse : JsonSerializable
+{
+    public static var typeName:String { return "UpdateTechnologyResponse" }
+    public static var metadata = Metadata.create([
+        Type<UpdateTechnologyResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        Type<UpdateTechnologyResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension DeleteTechnologyResponse : JsonSerializable
+{
+    public static var typeName:String { return "DeleteTechnologyResponse" }
+    public static var metadata = Metadata.create([
+        Type<DeleteTechnologyResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        Type<DeleteTechnologyResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension GetTechnologyResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<GetTechnologyResponse>.optionalObjectProperty("technology", get: { $0.technology }, set: { $0.technology = $1 }),
+        Type<GetTechnologyResponse>.arrayProperty("technologyStacks", get: { $0.technologyStacks }, set: { $0.technologyStacks = $1 }),
+        Type<GetTechnologyResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension GetTechnologyPreviousVersionsResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyPreviousVersionsResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyPreviousVersionsResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+        ])
+}
+
+extension GetTechnologyFavoriteDetailsResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyFavoriteDetailsResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyFavoriteDetailsResponse>.arrayProperty("users", get: { $0.users }, set: { $0.users = $1 }),
+        Type<GetTechnologyFavoriteDetailsResponse>.optionalProperty("favoriteCount", get: { $0.favoriteCount }, set: { $0.favoriteCount = $1 }),
+        ])
+}
+
+extension GetAllTechnologiesResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetAllTechnologiesResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetAllTechnologiesResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+        ])
+}
+
+extension QueryResponse : JsonSerializable
+{
+    public static var typeName:String { return "QueryResponse<T>" }
+    public static var metadata:Metadata {
+        return Metadata.create([
+            Type<QueryResponse<T>>.optionalProperty("offset", get: { $0.offset }, set: { $0.offset = $1 }),
+            Type<QueryResponse<T>>.optionalProperty("total", get: { $0.total }, set: { $0.total = $1 }),
+            Type<QueryResponse<T>>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+            Type<QueryResponse<T>>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+            Type<QueryResponse<T>>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+            ])
+    }
+}
+
+extension CreateTechnologyStackResponse : JsonSerializable
+{
+    public static var typeName:String { return "CreateTechnologyStackResponse" }
+    public static var metadata = Metadata.create([
+        Type<CreateTechnologyStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        Type<CreateTechnologyStackResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension UpdateTechnologyStackResponse : JsonSerializable
+{
+    public static var typeName:String { return "UpdateTechnologyStackResponse" }
+    public static var metadata = Metadata.create([
+        Type<UpdateTechnologyStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        Type<UpdateTechnologyStackResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension DeleteTechnologyStackResponse : JsonSerializable
+{
+    public static var typeName:String { return "DeleteTechnologyStackResponse" }
+    public static var metadata = Metadata.create([
+        Type<DeleteTechnologyStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        Type<DeleteTechnologyStackResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension GetAllTechnologyStacksResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetAllTechnologyStacksResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetAllTechnologyStacksResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+        ])
+}
+
+extension GetTechnologyStackResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyStackResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyStackResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<GetTechnologyStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        Type<GetTechnologyStackResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension GetTechnologyStackPreviousVersionsResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyStackPreviousVersionsResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyStackPreviousVersionsResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+        ])
+}
+
+extension GetTechnologyStackFavoriteDetailsResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetTechnologyStackFavoriteDetailsResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetTechnologyStackFavoriteDetailsResponse>.arrayProperty("users", get: { $0.users }, set: { $0.users = $1 }),
+        Type<GetTechnologyStackFavoriteDetailsResponse>.optionalProperty("favoriteCount", get: { $0.favoriteCount }, set: { $0.favoriteCount = $1 }),
+        ])
+}
+
+extension GetConfigResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetConfigResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetConfigResponse>.arrayProperty("allTiers", get: { $0.allTiers }, set: { $0.allTiers = $1 }),
+        ])
+}
+
+extension OverviewResponse : JsonSerializable
+{
+    public static var typeName:String { return "OverviewResponse" }
+    public static var metadata = Metadata.create([
+        Type<OverviewResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<OverviewResponse>.arrayProperty("topUsers", get: { $0.topUsers }, set: { $0.topUsers = $1 }),
+        Type<OverviewResponse>.arrayProperty("topTechnologies", get: { $0.topTechnologies }, set: { $0.topTechnologies = $1 }),
+        Type<OverviewResponse>.arrayProperty("latestTechStacks", get: { $0.latestTechStacks }, set: { $0.latestTechStacks = $1 }),
+        Type<OverviewResponse>.objectProperty("topTechnologiesByTier", get: { $0.topTechnologiesByTier }, set: { $0.topTechnologiesByTier = $1 }),
+        Type<OverviewResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension AppOverviewResponse : JsonSerializable
+{
+    public static var typeName:String { return "AppOverviewResponse" }
+    public static var metadata = Metadata.create([
+        Type<AppOverviewResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<AppOverviewResponse>.arrayProperty("allTiers", get: { $0.allTiers }, set: { $0.allTiers = $1 }),
+        Type<AppOverviewResponse>.arrayProperty("topTechnologies", get: { $0.topTechnologies }, set: { $0.topTechnologies = $1 }),
+        Type<AppOverviewResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension GetFavoriteTechStackResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetFavoriteTechStackResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetFavoriteTechStackResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+        ])
+}
+
+extension FavoriteTechStackResponse : JsonSerializable
+{
+    public static var typeName:String { return "FavoriteTechStackResponse" }
+    public static var metadata = Metadata.create([
+        Type<FavoriteTechStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        ])
+}
+
+extension GetFavoriteTechnologiesResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetFavoriteTechnologiesResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetFavoriteTechnologiesResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+        ])
+}
+
+extension FavoriteTechnologyResponse : JsonSerializable
+{
+    public static var typeName:String { return "FavoriteTechnologyResponse" }
+    public static var metadata = Metadata.create([
+        Type<FavoriteTechnologyResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
+        ])
+}
+
+extension GetUserFeedResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetUserFeedResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetUserFeedResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
+        ])
+}
+
+extension GetUserInfoResponse : JsonSerializable
+{
+    public static var typeName:String { return "GetUserInfoResponse" }
+    public static var metadata = Metadata.create([
+        Type<GetUserInfoResponse>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        Type<GetUserInfoResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<GetUserInfoResponse>.optionalProperty("avatarUrl", get: { $0.avatarUrl }, set: { $0.avatarUrl = $1 }),
+        Type<GetUserInfoResponse>.arrayProperty("techStacks", get: { $0.techStacks }, set: { $0.techStacks = $1 }),
+        Type<GetUserInfoResponse>.arrayProperty("favoriteTechStacks", get: { $0.favoriteTechStacks }, set: { $0.favoriteTechStacks = $1 }),
+        Type<GetUserInfoResponse>.arrayProperty("favoriteTechnologies", get: { $0.favoriteTechnologies }, set: { $0.favoriteTechnologies = $1 }),
+        ])
+}
+
+extension AuthenticateResponse : JsonSerializable
+{
+    public static var typeName:String { return "AuthenticateResponse" }
+    public static var metadata = Metadata.create([
+        Type<AuthenticateResponse>.optionalProperty("userId", get: { $0.userId }, set: { $0.userId = $1 }),
+        Type<AuthenticateResponse>.optionalProperty("sessionId", get: { $0.sessionId }, set: { $0.sessionId = $1 }),
+        Type<AuthenticateResponse>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        Type<AuthenticateResponse>.optionalProperty("displayName", get: { $0.displayName }, set: { $0.displayName = $1 }),
+        Type<AuthenticateResponse>.optionalProperty("referrerUrl", get: { $0.referrerUrl }, set: { $0.referrerUrl = $1 }),
+        Type<AuthenticateResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        Type<AuthenticateResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
+        ])
+}
+
+extension AssignRolesResponse : JsonSerializable
+{
+    public static var typeName:String { return "AssignRolesResponse" }
+    public static var metadata = Metadata.create([
+        Type<AssignRolesResponse>.arrayProperty("allRoles", get: { $0.allRoles }, set: { $0.allRoles = $1 }),
+        Type<AssignRolesResponse>.arrayProperty("allPermissions", get: { $0.allPermissions }, set: { $0.allPermissions = $1 }),
+        Type<AssignRolesResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
+
+extension UnAssignRolesResponse : JsonSerializable
+{
+    public static var typeName:String { return "UnAssignRolesResponse" }
+    public static var metadata = Metadata.create([
+        Type<UnAssignRolesResponse>.arrayProperty("allRoles", get: { $0.allRoles }, set: { $0.allRoles = $1 }),
+        Type<UnAssignRolesResponse>.arrayProperty("allPermissions", get: { $0.allPermissions }, set: { $0.allPermissions = $1 }),
+        Type<UnAssignRolesResponse>.optionalProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
+        ])
+}
 
 extension Technology : JsonSerializable
 {
-    public class var typeName:String { return "Technology" }
-    public class func reflect() -> Type<Technology> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<Technology>(
-            properties: [
-                Type<Technology>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-                Type<Technology>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<Technology>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<Technology>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
-                Type<Technology>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
-                Type<Technology>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
-                Type<Technology>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<Technology>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<Technology>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
-                Type<Technology>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
-                Type<Technology>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
-                Type<Technology>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
-                Type<Technology>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<Technology>.optionalProperty("logoApproved", get: { $0.logoApproved }, set: { $0.logoApproved = $1 }),
-                Type<Technology>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<Technology>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
-                Type<Technology>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return Technology.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> Technology? {
-        return Technology.reflect().fromJson(Technology(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> Technology? {
-        return Technology.reflect().fromObject(Technology(), any:any)
-    }
-    public func toString() -> String {
-        return Technology.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> Technology? {
-        return Technology.reflect().fromString(Technology(), string: string)
-    }
+    public static var typeName:String { return "Technology" }
+    public static var metadata = Metadata.create([
+        Type<Technology>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<Technology>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<Technology>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<Technology>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
+        Type<Technology>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
+        Type<Technology>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
+        Type<Technology>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<Technology>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<Technology>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
+        Type<Technology>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
+        Type<Technology>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
+        Type<Technology>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
+        Type<Technology>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<Technology>.optionalProperty("logoApproved", get: { $0.logoApproved }, set: { $0.logoApproved = $1 }),
+        Type<Technology>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<Technology>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
+        Type<Technology>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
+        ])
 }
 
 extension TechnologyTier : StringSerializable
@@ -945,2249 +1710,186 @@ extension TechnologyTier : StringSerializable
     }
 }
 
-extension ResponseStatus : JsonSerializable
-{
-    public class var typeName:String { return "ResponseStatus" }
-    public class func reflect() -> Type<ResponseStatus> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<ResponseStatus>(
-            properties: [
-                Type<ResponseStatus>.optionalProperty("errorCode", get: { $0.errorCode }, set: { $0.errorCode = $1 }),
-                Type<ResponseStatus>.optionalProperty("message", get: { $0.message }, set: { $0.message = $1 }),
-                Type<ResponseStatus>.optionalProperty("stackTrace", get: { $0.stackTrace }, set: { $0.stackTrace = $1 }),
-                Type<ResponseStatus>.arrayProperty("errors", get: { $0.errors }, set: { $0.errors = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return ResponseStatus.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> ResponseStatus? {
-        return ResponseStatus.reflect().fromJson(ResponseStatus(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> ResponseStatus? {
-        return ResponseStatus.reflect().fromObject(ResponseStatus(), any:any)
-    }
-    public func toString() -> String {
-        return ResponseStatus.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> ResponseStatus? {
-        return ResponseStatus.reflect().fromString(ResponseStatus(), string: string)
-    }
-}
-
 extension TechnologyStack : JsonSerializable
 {
-    public class var typeName:String { return "TechnologyStack" }
-    public class func reflect() -> Type<TechnologyStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<TechnologyStack>(
-            properties: [
-                Type<TechnologyStack>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-                Type<TechnologyStack>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<TechnologyStack>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<TechnologyStack>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<TechnologyStack>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
-                Type<TechnologyStack>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
-                Type<TechnologyStack>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<TechnologyStack>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
-                Type<TechnologyStack>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
-                Type<TechnologyStack>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
-                Type<TechnologyStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<TechnologyStack>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
-                Type<TechnologyStack>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<TechnologyStack>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
-                Type<TechnologyStack>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return TechnologyStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> TechnologyStack? {
-        return TechnologyStack.reflect().fromJson(TechnologyStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> TechnologyStack? {
-        return TechnologyStack.reflect().fromObject(TechnologyStack(), any:any)
-    }
-    public func toString() -> String {
-        return TechnologyStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> TechnologyStack? {
-        return TechnologyStack.reflect().fromString(TechnologyStack(), string: string)
-    }
+    public static var typeName:String { return "TechnologyStack" }
+    public static var metadata = Metadata.create([
+        Type<TechnologyStack>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<TechnologyStack>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<TechnologyStack>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<TechnologyStack>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<TechnologyStack>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
+        Type<TechnologyStack>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
+        Type<TechnologyStack>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<TechnologyStack>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
+        Type<TechnologyStack>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
+        Type<TechnologyStack>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
+        Type<TechnologyStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<TechnologyStack>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
+        Type<TechnologyStack>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<TechnologyStack>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
+        Type<TechnologyStack>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
+        ])
 }
 
 extension TechnologyHistory : JsonSerializable
 {
-    public class var typeName:String { return "TechnologyHistory" }
-    public class func reflect() -> Type<TechnologyHistory> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<TechnologyHistory>(
-            properties: [
-                Type<TechnologyHistory>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
-                Type<TechnologyHistory>.optionalProperty("operation", get: { $0.operation }, set: { $0.operation = $1 }),
-                Type<TechnologyHistory>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-                Type<TechnologyHistory>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<TechnologyHistory>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<TechnologyHistory>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
-                Type<TechnologyHistory>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
-                Type<TechnologyHistory>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
-                Type<TechnologyHistory>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<TechnologyHistory>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<TechnologyHistory>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
-                Type<TechnologyHistory>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
-                Type<TechnologyHistory>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
-                Type<TechnologyHistory>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
-                Type<TechnologyHistory>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<TechnologyHistory>.optionalProperty("logoApproved", get: { $0.logoApproved }, set: { $0.logoApproved = $1 }),
-                Type<TechnologyHistory>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<TechnologyHistory>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
-                Type<TechnologyHistory>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return TechnologyHistory.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> TechnologyHistory? {
-        return TechnologyHistory.reflect().fromJson(TechnologyHistory(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> TechnologyHistory? {
-        return TechnologyHistory.reflect().fromObject(TechnologyHistory(), any:any)
-    }
-    public func toString() -> String {
-        return TechnologyHistory.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> TechnologyHistory? {
-        return TechnologyHistory.reflect().fromString(TechnologyHistory(), string: string)
-    }
+    public static var typeName:String { return "TechnologyHistory" }
+    public static var metadata = Metadata.create([
+        Type<TechnologyHistory>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
+        Type<TechnologyHistory>.optionalProperty("operation", get: { $0.operation }, set: { $0.operation = $1 }),
+        Type<TechnologyHistory>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<TechnologyHistory>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<TechnologyHistory>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<TechnologyHistory>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
+        Type<TechnologyHistory>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
+        Type<TechnologyHistory>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
+        Type<TechnologyHistory>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<TechnologyHistory>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<TechnologyHistory>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
+        Type<TechnologyHistory>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
+        Type<TechnologyHistory>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
+        Type<TechnologyHistory>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
+        Type<TechnologyHistory>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<TechnologyHistory>.optionalProperty("logoApproved", get: { $0.logoApproved }, set: { $0.logoApproved = $1 }),
+        Type<TechnologyHistory>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<TechnologyHistory>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
+        Type<TechnologyHistory>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
+        ])
 }
 
 extension TechStackDetails : JsonSerializable
 {
-    public class var typeName:String { return "TechStackDetails" }
-    public class func reflect() -> Type<TechStackDetails> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<TechStackDetails>(
-            properties: [
-                Type<TechStackDetails>.optionalProperty("detailsHtml", get: { $0.detailsHtml }, set: { $0.detailsHtml = $1 }),
-                Type<TechStackDetails>.arrayProperty("technologyChoices", get: { $0.technologyChoices }, set: { $0.technologyChoices = $1 }),
-                Type<TechStackDetails>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-                Type<TechStackDetails>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<TechStackDetails>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<TechStackDetails>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<TechStackDetails>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
-                Type<TechStackDetails>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
-                Type<TechStackDetails>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<TechStackDetails>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
-                Type<TechStackDetails>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
-                Type<TechStackDetails>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
-                Type<TechStackDetails>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<TechStackDetails>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
-                Type<TechStackDetails>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<TechStackDetails>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
-                Type<TechStackDetails>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return TechStackDetails.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> TechStackDetails? {
-        return TechStackDetails.reflect().fromJson(TechStackDetails(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> TechStackDetails? {
-        return TechStackDetails.reflect().fromObject(TechStackDetails(), any:any)
-    }
-    public func toString() -> String {
-        return TechStackDetails.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> TechStackDetails? {
-        return TechStackDetails.reflect().fromString(TechStackDetails(), string: string)
-    }
+    public static var typeName:String { return "TechStackDetails" }
+    public static var metadata = Metadata.create([
+        Type<TechStackDetails>.optionalProperty("detailsHtml", get: { $0.detailsHtml }, set: { $0.detailsHtml = $1 }),
+        Type<TechStackDetails>.arrayProperty("technologyChoices", get: { $0.technologyChoices }, set: { $0.technologyChoices = $1 }),
+        Type<TechStackDetails>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<TechStackDetails>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<TechStackDetails>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<TechStackDetails>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<TechStackDetails>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
+        Type<TechStackDetails>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
+        Type<TechStackDetails>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<TechStackDetails>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
+        Type<TechStackDetails>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
+        Type<TechStackDetails>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
+        Type<TechStackDetails>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<TechStackDetails>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
+        Type<TechStackDetails>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<TechStackDetails>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
+        Type<TechStackDetails>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
+        ])
 }
 
 extension TechnologyStackHistory : JsonSerializable
 {
-    public class var typeName:String { return "TechnologyStackHistory" }
-    public class func reflect() -> Type<TechnologyStackHistory> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<TechnologyStackHistory>(
-            properties: [
-                Type<TechnologyStackHistory>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("operation", get: { $0.operation }, set: { $0.operation = $1 }),
-                Type<TechnologyStackHistory>.arrayProperty("technologyIds", get: { $0.technologyIds }, set: { $0.technologyIds = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
-                Type<TechnologyStackHistory>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return TechnologyStackHistory.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> TechnologyStackHistory? {
-        return TechnologyStackHistory.reflect().fromJson(TechnologyStackHistory(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> TechnologyStackHistory? {
-        return TechnologyStackHistory.reflect().fromObject(TechnologyStackHistory(), any:any)
-    }
-    public func toString() -> String {
-        return TechnologyStackHistory.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> TechnologyStackHistory? {
-        return TechnologyStackHistory.reflect().fromString(TechnologyStackHistory(), string: string)
-    }
+    public static var typeName:String { return "TechnologyStackHistory" }
+    public static var metadata = Metadata.create([
+        Type<TechnologyStackHistory>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("operation", get: { $0.operation }, set: { $0.operation = $1 }),
+        Type<TechnologyStackHistory>.arrayProperty("technologyIds", get: { $0.technologyIds }, set: { $0.technologyIds = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
+        Type<TechnologyStackHistory>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
+        ])
 }
 
 extension Option : JsonSerializable
 {
-    public class var typeName:String { return "Option" }
-    public class func reflect() -> Type<Option> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<Option>(
-            properties: [
-                Type<Option>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<Option>.optionalProperty("title", get: { $0.title }, set: { $0.title = $1 }),
-                Type<Option>.optionalProperty("value", get: { $0.value }, set: { $0.value = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return Option.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> Option? {
-        return Option.reflect().fromJson(Option(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> Option? {
-        return Option.reflect().fromObject(Option(), any:any)
-    }
-    public func toString() -> String {
-        return Option.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> Option? {
-        return Option.reflect().fromString(Option(), string: string)
-    }
+    public static var typeName:String { return "Option" }
+    public static var metadata = Metadata.create([
+        Type<Option>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<Option>.optionalProperty("title", get: { $0.title }, set: { $0.title = $1 }),
+        Type<Option>.optionalProperty("value", get: { $0.value }, set: { $0.value = $1 }),
+        ])
 }
 
 extension UserInfo : JsonSerializable
 {
-    public class var typeName:String { return "UserInfo" }
-    public class func reflect() -> Type<UserInfo> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<UserInfo>(
-            properties: [
-                Type<UserInfo>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
-                Type<UserInfo>.optionalProperty("avatarUrl", get: { $0.avatarUrl }, set: { $0.avatarUrl = $1 }),
-                Type<UserInfo>.optionalProperty("stacksCount", get: { $0.stacksCount }, set: { $0.stacksCount = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return UserInfo.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> UserInfo? {
-        return UserInfo.reflect().fromJson(UserInfo(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> UserInfo? {
-        return UserInfo.reflect().fromObject(UserInfo(), any:any)
-    }
-    public func toString() -> String {
-        return UserInfo.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> UserInfo? {
-        return UserInfo.reflect().fromString(UserInfo(), string: string)
-    }
+    public static var typeName:String { return "UserInfo" }
+    public static var metadata = Metadata.create([
+        Type<UserInfo>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        Type<UserInfo>.optionalProperty("avatarUrl", get: { $0.avatarUrl }, set: { $0.avatarUrl = $1 }),
+        Type<UserInfo>.optionalProperty("stacksCount", get: { $0.stacksCount }, set: { $0.stacksCount = $1 }),
+        ])
 }
 
 extension TechnologyInfo : JsonSerializable
 {
-    public class var typeName:String { return "TechnologyInfo" }
-    public class func reflect() -> Type<TechnologyInfo> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<TechnologyInfo>(
-            properties: [
-                Type<TechnologyInfo>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
-                Type<TechnologyInfo>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<TechnologyInfo>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<TechnologyInfo>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
-                Type<TechnologyInfo>.optionalProperty("stacksCount", get: { $0.stacksCount }, set: { $0.stacksCount = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return TechnologyInfo.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> TechnologyInfo? {
-        return TechnologyInfo.reflect().fromJson(TechnologyInfo(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> TechnologyInfo? {
-        return TechnologyInfo.reflect().fromObject(TechnologyInfo(), any:any)
-    }
-    public func toString() -> String {
-        return TechnologyInfo.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> TechnologyInfo? {
-        return TechnologyInfo.reflect().fromString(TechnologyInfo(), string: string)
-    }
+    public static var typeName:String { return "TechnologyInfo" }
+    public static var metadata = Metadata.create([
+        Type<TechnologyInfo>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
+        Type<TechnologyInfo>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<TechnologyInfo>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<TechnologyInfo>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
+        Type<TechnologyInfo>.optionalProperty("stacksCount", get: { $0.stacksCount }, set: { $0.stacksCount = $1 }),
+        ])
 }
 
-extension ResponseError : JsonSerializable
+extension Post : JsonSerializable
 {
-    public class var typeName:String { return "ResponseError" }
-    public class func reflect() -> Type<ResponseError> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<ResponseError>(
-            properties: [
-                Type<ResponseError>.optionalProperty("errorCode", get: { $0.errorCode }, set: { $0.errorCode = $1 }),
-                Type<ResponseError>.optionalProperty("fieldName", get: { $0.fieldName }, set: { $0.fieldName = $1 }),
-                Type<ResponseError>.optionalProperty("message", get: { $0.message }, set: { $0.message = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return ResponseError.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> ResponseError? {
-        return ResponseError.reflect().fromJson(ResponseError(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> ResponseError? {
-        return ResponseError.reflect().fromObject(ResponseError(), any:any)
-    }
-    public func toString() -> String {
-        return ResponseError.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> ResponseError? {
-        return ResponseError.reflect().fromString(ResponseError(), string: string)
-    }
+    public static var typeName:String { return "Post" }
+    public static var metadata = Metadata.create([
+        Type<Post>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<Post>.optionalProperty("userId", get: { $0.userId }, set: { $0.userId = $1 }),
+        Type<Post>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        Type<Post>.optionalProperty("date", get: { $0.date }, set: { $0.date = $1 }),
+        Type<Post>.optionalProperty("shortDate", get: { $0.shortDate }, set: { $0.shortDate = $1 }),
+        Type<Post>.optionalProperty("textHtml", get: { $0.textHtml }, set: { $0.textHtml = $1 }),
+        Type<Post>.arrayProperty("comments", get: { $0.comments }, set: { $0.comments = $1 }),
+        ])
 }
 
 extension TechnologyInStack : JsonSerializable
 {
-    public class var typeName:String { return "TechnologyInStack" }
-    public class func reflect() -> Type<TechnologyInStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<TechnologyInStack>(
-            properties: [
-                Type<TechnologyInStack>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
-                Type<TechnologyInStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
-                Type<TechnologyInStack>.optionalProperty("justification", get: { $0.justification }, set: { $0.justification = $1 }),
-                Type<TechnologyInStack>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-                Type<TechnologyInStack>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<TechnologyInStack>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<TechnologyInStack>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
-                Type<TechnologyInStack>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
-                Type<TechnologyInStack>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
-                Type<TechnologyInStack>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<TechnologyInStack>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<TechnologyInStack>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
-                Type<TechnologyInStack>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
-                Type<TechnologyInStack>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
-                Type<TechnologyInStack>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
-                Type<TechnologyInStack>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<TechnologyInStack>.optionalProperty("logoApproved", get: { $0.logoApproved }, set: { $0.logoApproved = $1 }),
-                Type<TechnologyInStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<TechnologyInStack>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
-                Type<TechnologyInStack>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return TechnologyInStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> TechnologyInStack? {
-        return TechnologyInStack.reflect().fromJson(TechnologyInStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> TechnologyInStack? {
-        return TechnologyInStack.reflect().fromObject(TechnologyInStack(), any:any)
-    }
-    public func toString() -> String {
-        return TechnologyInStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> TechnologyInStack? {
-        return TechnologyInStack.reflect().fromString(TechnologyInStack(), string: string)
-    }
-}
-
-extension LogoUrlApprovalResponse : JsonSerializable
-{
-    public class var typeName:String { return "LogoUrlApprovalResponse" }
-    public class func reflect() -> Type<LogoUrlApprovalResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<LogoUrlApprovalResponse>(
-            properties: [
-                Type<LogoUrlApprovalResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return LogoUrlApprovalResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> LogoUrlApprovalResponse? {
-        return LogoUrlApprovalResponse.reflect().fromJson(LogoUrlApprovalResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> LogoUrlApprovalResponse? {
-        return LogoUrlApprovalResponse.reflect().fromObject(LogoUrlApprovalResponse(), any:any)
-    }
-    public func toString() -> String {
-        return LogoUrlApprovalResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> LogoUrlApprovalResponse? {
-        return LogoUrlApprovalResponse.reflect().fromString(LogoUrlApprovalResponse(), string: string)
-    }
-}
-
-extension LockStackResponse : JsonSerializable
-{
-    public class var typeName:String { return "LockStackResponse" }
-    public class func reflect() -> Type<LockStackResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<LockStackResponse>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return LockStackResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> LockStackResponse? {
-        return LockStackResponse.reflect().fromJson(LockStackResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> LockStackResponse? {
-        return LockStackResponse.reflect().fromObject(LockStackResponse(), any:any)
-    }
-    public func toString() -> String {
-        return LockStackResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> LockStackResponse? {
-        return LockStackResponse.reflect().fromString(LockStackResponse(), string: string)
-    }
-}
-
-extension CreateTechnologyResponse : JsonSerializable
-{
-    public class var typeName:String { return "CreateTechnologyResponse" }
-    public class func reflect() -> Type<CreateTechnologyResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<CreateTechnologyResponse>(
-            properties: [
-                Type<CreateTechnologyResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-                Type<CreateTechnologyResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return CreateTechnologyResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> CreateTechnologyResponse? {
-        return CreateTechnologyResponse.reflect().fromJson(CreateTechnologyResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> CreateTechnologyResponse? {
-        return CreateTechnologyResponse.reflect().fromObject(CreateTechnologyResponse(), any:any)
-    }
-    public func toString() -> String {
-        return CreateTechnologyResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> CreateTechnologyResponse? {
-        return CreateTechnologyResponse.reflect().fromString(CreateTechnologyResponse(), string: string)
-    }
-}
-
-extension UpdateTechnologyResponse : JsonSerializable
-{
-    public class var typeName:String { return "UpdateTechnologyResponse" }
-    public class func reflect() -> Type<UpdateTechnologyResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<UpdateTechnologyResponse>(
-            properties: [
-                Type<UpdateTechnologyResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-                Type<UpdateTechnologyResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return UpdateTechnologyResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> UpdateTechnologyResponse? {
-        return UpdateTechnologyResponse.reflect().fromJson(UpdateTechnologyResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> UpdateTechnologyResponse? {
-        return UpdateTechnologyResponse.reflect().fromObject(UpdateTechnologyResponse(), any:any)
-    }
-    public func toString() -> String {
-        return UpdateTechnologyResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> UpdateTechnologyResponse? {
-        return UpdateTechnologyResponse.reflect().fromString(UpdateTechnologyResponse(), string: string)
-    }
-}
-
-extension DeleteTechnologyResponse : JsonSerializable
-{
-    public class var typeName:String { return "DeleteTechnologyResponse" }
-    public class func reflect() -> Type<DeleteTechnologyResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<DeleteTechnologyResponse>(
-            properties: [
-                Type<DeleteTechnologyResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-                Type<DeleteTechnologyResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return DeleteTechnologyResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> DeleteTechnologyResponse? {
-        return DeleteTechnologyResponse.reflect().fromJson(DeleteTechnologyResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> DeleteTechnologyResponse? {
-        return DeleteTechnologyResponse.reflect().fromObject(DeleteTechnologyResponse(), any:any)
-    }
-    public func toString() -> String {
-        return DeleteTechnologyResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> DeleteTechnologyResponse? {
-        return DeleteTechnologyResponse.reflect().fromString(DeleteTechnologyResponse(), string: string)
-    }
-}
-
-extension GetTechnologyResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyResponse" }
-    public class func reflect() -> Type<GetTechnologyResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyResponse>(
-            properties: [
-                Type<GetTechnologyResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<GetTechnologyResponse>.optionalObjectProperty("technology", get: { $0.technology }, set: { $0.technology = $1 }),
-                Type<GetTechnologyResponse>.arrayProperty("technologyStacks", get: { $0.technologyStacks }, set: { $0.technologyStacks = $1 }),
-                Type<GetTechnologyResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyResponse? {
-        return GetTechnologyResponse.reflect().fromJson(GetTechnologyResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyResponse? {
-        return GetTechnologyResponse.reflect().fromObject(GetTechnologyResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyResponse? {
-        return GetTechnologyResponse.reflect().fromString(GetTechnologyResponse(), string: string)
-    }
-}
-
-extension GetTechnologyPreviousVersionsResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyPreviousVersionsResponse" }
-    public class func reflect() -> Type<GetTechnologyPreviousVersionsResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyPreviousVersionsResponse>(
-            properties: [
-                Type<GetTechnologyPreviousVersionsResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyPreviousVersionsResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyPreviousVersionsResponse? {
-        return GetTechnologyPreviousVersionsResponse.reflect().fromJson(GetTechnologyPreviousVersionsResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyPreviousVersionsResponse? {
-        return GetTechnologyPreviousVersionsResponse.reflect().fromObject(GetTechnologyPreviousVersionsResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyPreviousVersionsResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyPreviousVersionsResponse? {
-        return GetTechnologyPreviousVersionsResponse.reflect().fromString(GetTechnologyPreviousVersionsResponse(), string: string)
-    }
-}
-
-extension GetTechnologyFavoriteDetailsResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyFavoriteDetailsResponse" }
-    public class func reflect() -> Type<GetTechnologyFavoriteDetailsResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyFavoriteDetailsResponse>(
-            properties: [
-                Type<GetTechnologyFavoriteDetailsResponse>.arrayProperty("users", get: { $0.users }, set: { $0.users = $1 }),
-                Type<GetTechnologyFavoriteDetailsResponse>.optionalProperty("favoriteCount", get: { $0.favoriteCount }, set: { $0.favoriteCount = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyFavoriteDetailsResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyFavoriteDetailsResponse? {
-        return GetTechnologyFavoriteDetailsResponse.reflect().fromJson(GetTechnologyFavoriteDetailsResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyFavoriteDetailsResponse? {
-        return GetTechnologyFavoriteDetailsResponse.reflect().fromObject(GetTechnologyFavoriteDetailsResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyFavoriteDetailsResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyFavoriteDetailsResponse? {
-        return GetTechnologyFavoriteDetailsResponse.reflect().fromString(GetTechnologyFavoriteDetailsResponse(), string: string)
-    }
-}
-
-extension GetAllTechnologiesResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetAllTechnologiesResponse" }
-    public class func reflect() -> Type<GetAllTechnologiesResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetAllTechnologiesResponse>(
-            properties: [
-                Type<GetAllTechnologiesResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetAllTechnologiesResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetAllTechnologiesResponse? {
-        return GetAllTechnologiesResponse.reflect().fromJson(GetAllTechnologiesResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetAllTechnologiesResponse? {
-        return GetAllTechnologiesResponse.reflect().fromObject(GetAllTechnologiesResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetAllTechnologiesResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetAllTechnologiesResponse? {
-        return GetAllTechnologiesResponse.reflect().fromString(GetAllTechnologiesResponse(), string: string)
-    }
-}
-
-extension QueryResponse : JsonSerializable
-{
-    public class var typeName:String { return "QueryResponse<Technology>" }
-    public class func reflect() -> Type<QueryResponse<Technology>> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<QueryResponse<Technology>>(
-            properties: [
-                Type<QueryResponse<Technology>>.optionalProperty("offset", get: { $0.offset }, set: { $0.offset = $1 }),
-                Type<QueryResponse<Technology>>.optionalProperty("total", get: { $0.total }, set: { $0.total = $1 }),
-                Type<QueryResponse<Technology>>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-                Type<QueryResponse<Technology>>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
-                Type<QueryResponse<Technology>>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return QueryResponse<Technology>.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> QueryResponse<Technology>? {
-        return QueryResponse<Technology>.reflect().fromJson(QueryResponse<Technology>(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> QueryResponse<Technology>? {
-        return QueryResponse<Technology>.reflect().fromObject(QueryResponse<Technology>(), any:any)
-    }
-    public func toString() -> String {
-        return QueryResponse<Technology>.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> QueryResponse<Technology>? {
-        return QueryResponse<Technology>.reflect().fromString(QueryResponse<Technology>(), string: string)
-    }
-}
-
-extension CreateTechnologyStackResponse : JsonSerializable
-{
-    public class var typeName:String { return "CreateTechnologyStackResponse" }
-    public class func reflect() -> Type<CreateTechnologyStackResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<CreateTechnologyStackResponse>(
-            properties: [
-                Type<CreateTechnologyStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-                Type<CreateTechnologyStackResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return CreateTechnologyStackResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> CreateTechnologyStackResponse? {
-        return CreateTechnologyStackResponse.reflect().fromJson(CreateTechnologyStackResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> CreateTechnologyStackResponse? {
-        return CreateTechnologyStackResponse.reflect().fromObject(CreateTechnologyStackResponse(), any:any)
-    }
-    public func toString() -> String {
-        return CreateTechnologyStackResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> CreateTechnologyStackResponse? {
-        return CreateTechnologyStackResponse.reflect().fromString(CreateTechnologyStackResponse(), string: string)
-    }
-}
-
-extension UpdateTechnologyStackResponse : JsonSerializable
-{
-    public class var typeName:String { return "UpdateTechnologyStackResponse" }
-    public class func reflect() -> Type<UpdateTechnologyStackResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<UpdateTechnologyStackResponse>(
-            properties: [
-                Type<UpdateTechnologyStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-                Type<UpdateTechnologyStackResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return UpdateTechnologyStackResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> UpdateTechnologyStackResponse? {
-        return UpdateTechnologyStackResponse.reflect().fromJson(UpdateTechnologyStackResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> UpdateTechnologyStackResponse? {
-        return UpdateTechnologyStackResponse.reflect().fromObject(UpdateTechnologyStackResponse(), any:any)
-    }
-    public func toString() -> String {
-        return UpdateTechnologyStackResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> UpdateTechnologyStackResponse? {
-        return UpdateTechnologyStackResponse.reflect().fromString(UpdateTechnologyStackResponse(), string: string)
-    }
-}
-
-extension DeleteTechnologyStackResponse : JsonSerializable
-{
-    public class var typeName:String { return "DeleteTechnologyStackResponse" }
-    public class func reflect() -> Type<DeleteTechnologyStackResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<DeleteTechnologyStackResponse>(
-            properties: [
-                Type<DeleteTechnologyStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-                Type<DeleteTechnologyStackResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return DeleteTechnologyStackResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> DeleteTechnologyStackResponse? {
-        return DeleteTechnologyStackResponse.reflect().fromJson(DeleteTechnologyStackResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> DeleteTechnologyStackResponse? {
-        return DeleteTechnologyStackResponse.reflect().fromObject(DeleteTechnologyStackResponse(), any:any)
-    }
-    public func toString() -> String {
-        return DeleteTechnologyStackResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> DeleteTechnologyStackResponse? {
-        return DeleteTechnologyStackResponse.reflect().fromString(DeleteTechnologyStackResponse(), string: string)
-    }
-}
-
-extension GetAllTechnologyStacksResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetAllTechnologyStacksResponse" }
-    public class func reflect() -> Type<GetAllTechnologyStacksResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetAllTechnologyStacksResponse>(
-            properties: [
-                Type<GetAllTechnologyStacksResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetAllTechnologyStacksResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetAllTechnologyStacksResponse? {
-        return GetAllTechnologyStacksResponse.reflect().fromJson(GetAllTechnologyStacksResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetAllTechnologyStacksResponse? {
-        return GetAllTechnologyStacksResponse.reflect().fromObject(GetAllTechnologyStacksResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetAllTechnologyStacksResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetAllTechnologyStacksResponse? {
-        return GetAllTechnologyStacksResponse.reflect().fromString(GetAllTechnologyStacksResponse(), string: string)
-    }
-}
-
-extension GetTechnologyStackResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyStackResponse" }
-    public class func reflect() -> Type<GetTechnologyStackResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyStackResponse>(
-            properties: [
-                Type<GetTechnologyStackResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<GetTechnologyStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-                Type<GetTechnologyStackResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyStackResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyStackResponse? {
-        return GetTechnologyStackResponse.reflect().fromJson(GetTechnologyStackResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyStackResponse? {
-        return GetTechnologyStackResponse.reflect().fromObject(GetTechnologyStackResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyStackResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyStackResponse? {
-        return GetTechnologyStackResponse.reflect().fromString(GetTechnologyStackResponse(), string: string)
-    }
-}
-
-extension GetTechnologyStackPreviousVersionsResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyStackPreviousVersionsResponse" }
-    public class func reflect() -> Type<GetTechnologyStackPreviousVersionsResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyStackPreviousVersionsResponse>(
-            properties: [
-                Type<GetTechnologyStackPreviousVersionsResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyStackPreviousVersionsResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyStackPreviousVersionsResponse? {
-        return GetTechnologyStackPreviousVersionsResponse.reflect().fromJson(GetTechnologyStackPreviousVersionsResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyStackPreviousVersionsResponse? {
-        return GetTechnologyStackPreviousVersionsResponse.reflect().fromObject(GetTechnologyStackPreviousVersionsResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyStackPreviousVersionsResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyStackPreviousVersionsResponse? {
-        return GetTechnologyStackPreviousVersionsResponse.reflect().fromString(GetTechnologyStackPreviousVersionsResponse(), string: string)
-    }
-}
-
-extension GetTechnologyStackFavoriteDetailsResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyStackFavoriteDetailsResponse" }
-    public class func reflect() -> Type<GetTechnologyStackFavoriteDetailsResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyStackFavoriteDetailsResponse>(
-            properties: [
-                Type<GetTechnologyStackFavoriteDetailsResponse>.arrayProperty("users", get: { $0.users }, set: { $0.users = $1 }),
-                Type<GetTechnologyStackFavoriteDetailsResponse>.optionalProperty("favoriteCount", get: { $0.favoriteCount }, set: { $0.favoriteCount = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyStackFavoriteDetailsResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyStackFavoriteDetailsResponse? {
-        return GetTechnologyStackFavoriteDetailsResponse.reflect().fromJson(GetTechnologyStackFavoriteDetailsResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyStackFavoriteDetailsResponse? {
-        return GetTechnologyStackFavoriteDetailsResponse.reflect().fromObject(GetTechnologyStackFavoriteDetailsResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyStackFavoriteDetailsResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyStackFavoriteDetailsResponse? {
-        return GetTechnologyStackFavoriteDetailsResponse.reflect().fromString(GetTechnologyStackFavoriteDetailsResponse(), string: string)
-    }
-}
-
-extension GetConfigResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetConfigResponse" }
-    public class func reflect() -> Type<GetConfigResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetConfigResponse>(
-            properties: [
-                Type<GetConfigResponse>.arrayProperty("allTiers", get: { $0.allTiers }, set: { $0.allTiers = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetConfigResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetConfigResponse? {
-        return GetConfigResponse.reflect().fromJson(GetConfigResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetConfigResponse? {
-        return GetConfigResponse.reflect().fromObject(GetConfigResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetConfigResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetConfigResponse? {
-        return GetConfigResponse.reflect().fromString(GetConfigResponse(), string: string)
-    }
-}
-
-extension OverviewResponse : JsonSerializable
-{
-    public class var typeName:String { return "OverviewResponse" }
-    public class func reflect() -> Type<OverviewResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<OverviewResponse>(
-            properties: [
-                Type<OverviewResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<OverviewResponse>.arrayProperty("topUsers", get: { $0.topUsers }, set: { $0.topUsers = $1 }),
-                Type<OverviewResponse>.arrayProperty("topTechnologies", get: { $0.topTechnologies }, set: { $0.topTechnologies = $1 }),
-                Type<OverviewResponse>.arrayProperty("latestTechStacks", get: { $0.latestTechStacks }, set: { $0.latestTechStacks = $1 }),
-                Type<OverviewResponse>.objectProperty("topTechnologiesByTier", get: { $0.topTechnologiesByTier }, set: { $0.topTechnologiesByTier = $1 }),
-                Type<OverviewResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return OverviewResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> OverviewResponse? {
-        return OverviewResponse.reflect().fromJson(OverviewResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> OverviewResponse? {
-        return OverviewResponse.reflect().fromObject(OverviewResponse(), any:any)
-    }
-    public func toString() -> String {
-        return OverviewResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> OverviewResponse? {
-        return OverviewResponse.reflect().fromString(OverviewResponse(), string: string)
-    }
-}
-
-extension AppOverviewResponse : JsonSerializable
-{
-    public class var typeName:String { return "AppOverviewResponse" }
-    public class func reflect() -> Type<AppOverviewResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<AppOverviewResponse>(
-            properties: [
-                Type<AppOverviewResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<AppOverviewResponse>.arrayProperty("allTiers", get: { $0.allTiers }, set: { $0.allTiers = $1 }),
-                Type<AppOverviewResponse>.arrayProperty("topTechnologies", get: { $0.topTechnologies }, set: { $0.topTechnologies = $1 }),
-                Type<AppOverviewResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return AppOverviewResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> AppOverviewResponse? {
-        return AppOverviewResponse.reflect().fromJson(AppOverviewResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> AppOverviewResponse? {
-        return AppOverviewResponse.reflect().fromObject(AppOverviewResponse(), any:any)
-    }
-    public func toString() -> String {
-        return AppOverviewResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> AppOverviewResponse? {
-        return AppOverviewResponse.reflect().fromString(AppOverviewResponse(), string: string)
-    }
-}
-
-extension GetFavoriteTechStackResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetFavoriteTechStackResponse" }
-    public class func reflect() -> Type<GetFavoriteTechStackResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetFavoriteTechStackResponse>(
-            properties: [
-                Type<GetFavoriteTechStackResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetFavoriteTechStackResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetFavoriteTechStackResponse? {
-        return GetFavoriteTechStackResponse.reflect().fromJson(GetFavoriteTechStackResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetFavoriteTechStackResponse? {
-        return GetFavoriteTechStackResponse.reflect().fromObject(GetFavoriteTechStackResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetFavoriteTechStackResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetFavoriteTechStackResponse? {
-        return GetFavoriteTechStackResponse.reflect().fromString(GetFavoriteTechStackResponse(), string: string)
-    }
-}
-
-extension FavoriteTechStackResponse : JsonSerializable
-{
-    public class var typeName:String { return "FavoriteTechStackResponse" }
-    public class func reflect() -> Type<FavoriteTechStackResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<FavoriteTechStackResponse>(
-            properties: [
-                Type<FavoriteTechStackResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return FavoriteTechStackResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> FavoriteTechStackResponse? {
-        return FavoriteTechStackResponse.reflect().fromJson(FavoriteTechStackResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> FavoriteTechStackResponse? {
-        return FavoriteTechStackResponse.reflect().fromObject(FavoriteTechStackResponse(), any:any)
-    }
-    public func toString() -> String {
-        return FavoriteTechStackResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> FavoriteTechStackResponse? {
-        return FavoriteTechStackResponse.reflect().fromString(FavoriteTechStackResponse(), string: string)
-    }
-}
-
-extension GetFavoriteTechnologiesResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetFavoriteTechnologiesResponse" }
-    public class func reflect() -> Type<GetFavoriteTechnologiesResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetFavoriteTechnologiesResponse>(
-            properties: [
-                Type<GetFavoriteTechnologiesResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetFavoriteTechnologiesResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetFavoriteTechnologiesResponse? {
-        return GetFavoriteTechnologiesResponse.reflect().fromJson(GetFavoriteTechnologiesResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetFavoriteTechnologiesResponse? {
-        return GetFavoriteTechnologiesResponse.reflect().fromObject(GetFavoriteTechnologiesResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetFavoriteTechnologiesResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetFavoriteTechnologiesResponse? {
-        return GetFavoriteTechnologiesResponse.reflect().fromString(GetFavoriteTechnologiesResponse(), string: string)
-    }
-}
-
-extension FavoriteTechnologyResponse : JsonSerializable
-{
-    public class var typeName:String { return "FavoriteTechnologyResponse" }
-    public class func reflect() -> Type<FavoriteTechnologyResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<FavoriteTechnologyResponse>(
-            properties: [
-                Type<FavoriteTechnologyResponse>.optionalObjectProperty("result", get: { $0.result }, set: { $0.result = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return FavoriteTechnologyResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> FavoriteTechnologyResponse? {
-        return FavoriteTechnologyResponse.reflect().fromJson(FavoriteTechnologyResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> FavoriteTechnologyResponse? {
-        return FavoriteTechnologyResponse.reflect().fromObject(FavoriteTechnologyResponse(), any:any)
-    }
-    public func toString() -> String {
-        return FavoriteTechnologyResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> FavoriteTechnologyResponse? {
-        return FavoriteTechnologyResponse.reflect().fromString(FavoriteTechnologyResponse(), string: string)
-    }
-}
-
-extension GetUserFeedResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetUserFeedResponse" }
-    public class func reflect() -> Type<GetUserFeedResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetUserFeedResponse>(
-            properties: [
-                Type<GetUserFeedResponse>.arrayProperty("results", get: { $0.results }, set: { $0.results = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetUserFeedResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetUserFeedResponse? {
-        return GetUserFeedResponse.reflect().fromJson(GetUserFeedResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetUserFeedResponse? {
-        return GetUserFeedResponse.reflect().fromObject(GetUserFeedResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetUserFeedResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetUserFeedResponse? {
-        return GetUserFeedResponse.reflect().fromString(GetUserFeedResponse(), string: string)
-    }
-}
-
-extension GetUserInfoResponse : JsonSerializable
-{
-    public class var typeName:String { return "GetUserInfoResponse" }
-    public class func reflect() -> Type<GetUserInfoResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetUserInfoResponse>(
-            properties: [
-                Type<GetUserInfoResponse>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
-                Type<GetUserInfoResponse>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
-                Type<GetUserInfoResponse>.optionalProperty("avatarUrl", get: { $0.avatarUrl }, set: { $0.avatarUrl = $1 }),
-                Type<GetUserInfoResponse>.arrayProperty("techStacks", get: { $0.techStacks }, set: { $0.techStacks = $1 }),
-                Type<GetUserInfoResponse>.arrayProperty("favoriteTechStacks", get: { $0.favoriteTechStacks }, set: { $0.favoriteTechStacks = $1 }),
-                Type<GetUserInfoResponse>.arrayProperty("favoriteTechnologies", get: { $0.favoriteTechnologies }, set: { $0.favoriteTechnologies = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetUserInfoResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetUserInfoResponse? {
-        return GetUserInfoResponse.reflect().fromJson(GetUserInfoResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetUserInfoResponse? {
-        return GetUserInfoResponse.reflect().fromObject(GetUserInfoResponse(), any:any)
-    }
-    public func toString() -> String {
-        return GetUserInfoResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetUserInfoResponse? {
-        return GetUserInfoResponse.reflect().fromString(GetUserInfoResponse(), string: string)
-    }
-}
-
-extension AuthenticateResponse : JsonSerializable
-{
-    public class var typeName:String { return "AuthenticateResponse" }
-    public class func reflect() -> Type<AuthenticateResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<AuthenticateResponse>(
-            properties: [
-                Type<AuthenticateResponse>.optionalProperty("userId", get: { $0.userId }, set: { $0.userId = $1 }),
-                Type<AuthenticateResponse>.optionalProperty("sessionId", get: { $0.sessionId }, set: { $0.sessionId = $1 }),
-                Type<AuthenticateResponse>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
-                Type<AuthenticateResponse>.optionalProperty("displayName", get: { $0.displayName }, set: { $0.displayName = $1 }),
-                Type<AuthenticateResponse>.optionalProperty("referrerUrl", get: { $0.referrerUrl }, set: { $0.referrerUrl = $1 }),
-                Type<AuthenticateResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-                Type<AuthenticateResponse>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return AuthenticateResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> AuthenticateResponse? {
-        return AuthenticateResponse.reflect().fromJson(AuthenticateResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> AuthenticateResponse? {
-        return AuthenticateResponse.reflect().fromObject(AuthenticateResponse(), any:any)
-    }
-    public func toString() -> String {
-        return AuthenticateResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> AuthenticateResponse? {
-        return AuthenticateResponse.reflect().fromString(AuthenticateResponse(), string: string)
-    }
-}
-
-extension AssignRolesResponse : JsonSerializable
-{
-    public class var typeName:String { return "AssignRolesResponse" }
-    public class func reflect() -> Type<AssignRolesResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<AssignRolesResponse>(
-            properties: [
-                Type<AssignRolesResponse>.arrayProperty("allRoles", get: { $0.allRoles }, set: { $0.allRoles = $1 }),
-                Type<AssignRolesResponse>.arrayProperty("allPermissions", get: { $0.allPermissions }, set: { $0.allPermissions = $1 }),
-                Type<AssignRolesResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return AssignRolesResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> AssignRolesResponse? {
-        return AssignRolesResponse.reflect().fromJson(AssignRolesResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> AssignRolesResponse? {
-        return AssignRolesResponse.reflect().fromObject(AssignRolesResponse(), any:any)
-    }
-    public func toString() -> String {
-        return AssignRolesResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> AssignRolesResponse? {
-        return AssignRolesResponse.reflect().fromString(AssignRolesResponse(), string: string)
-    }
-}
-
-extension UnAssignRolesResponse : JsonSerializable
-{
-    public class var typeName:String { return "UnAssignRolesResponse" }
-    public class func reflect() -> Type<UnAssignRolesResponse> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<UnAssignRolesResponse>(
-            properties: [
-                Type<UnAssignRolesResponse>.arrayProperty("allRoles", get: { $0.allRoles }, set: { $0.allRoles = $1 }),
-                Type<UnAssignRolesResponse>.arrayProperty("allPermissions", get: { $0.allPermissions }, set: { $0.allPermissions = $1 }),
-                Type<UnAssignRolesResponse>.optionalObjectProperty("responseStatus", get: { $0.responseStatus }, set: { $0.responseStatus = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return UnAssignRolesResponse.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> UnAssignRolesResponse? {
-        return UnAssignRolesResponse.reflect().fromJson(UnAssignRolesResponse(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> UnAssignRolesResponse? {
-        return UnAssignRolesResponse.reflect().fromObject(UnAssignRolesResponse(), any:any)
-    }
-    public func toString() -> String {
-        return UnAssignRolesResponse.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> UnAssignRolesResponse? {
-        return UnAssignRolesResponse.reflect().fromString(UnAssignRolesResponse(), string: string)
-    }
-}
-
-extension LogoUrlApproval : JsonSerializable
-{
-    public class var typeName:String { return "LogoUrlApproval" }
-    public class func reflect() -> Type<LogoUrlApproval> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<LogoUrlApproval>(
-            properties: [
-                Type<LogoUrlApproval>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
-                Type<LogoUrlApproval>.optionalProperty("approved", get: { $0.approved }, set: { $0.approved = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return LogoUrlApproval.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> LogoUrlApproval? {
-        return LogoUrlApproval.reflect().fromJson(LogoUrlApproval(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> LogoUrlApproval? {
-        return LogoUrlApproval.reflect().fromObject(LogoUrlApproval(), any:any)
-    }
-    public func toString() -> String {
-        return LogoUrlApproval.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> LogoUrlApproval? {
-        return LogoUrlApproval.reflect().fromString(LogoUrlApproval(), string: string)
-    }
-}
-
-extension LockTechStack : JsonSerializable
-{
-    public class var typeName:String { return "LockTechStack" }
-    public class func reflect() -> Type<LockTechStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<LockTechStack>(
-            properties: [
-                Type<LockTechStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
-                Type<LockTechStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return LockTechStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> LockTechStack? {
-        return LockTechStack.reflect().fromJson(LockTechStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> LockTechStack? {
-        return LockTechStack.reflect().fromObject(LockTechStack(), any:any)
-    }
-    public func toString() -> String {
-        return LockTechStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> LockTechStack? {
-        return LockTechStack.reflect().fromString(LockTechStack(), string: string)
-    }
-}
-
-extension LockTech : JsonSerializable
-{
-    public class var typeName:String { return "LockTech" }
-    public class func reflect() -> Type<LockTech> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<LockTech>(
-            properties: [
-                Type<LockTech>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
-                Type<LockTech>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return LockTech.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> LockTech? {
-        return LockTech.reflect().fromJson(LockTech(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> LockTech? {
-        return LockTech.reflect().fromObject(LockTech(), any:any)
-    }
-    public func toString() -> String {
-        return LockTech.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> LockTech? {
-        return LockTech.reflect().fromString(LockTech(), string: string)
-    }
-}
-
-extension Ping : JsonSerializable
-{
-    public class var typeName:String { return "Ping" }
-    public class func reflect() -> Type<Ping> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<Ping>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return Ping.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> Ping? {
-        return Ping.reflect().fromJson(Ping(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> Ping? {
-        return Ping.reflect().fromObject(Ping(), any:any)
-    }
-    public func toString() -> String {
-        return Ping.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> Ping? {
-        return Ping.reflect().fromString(Ping(), string: string)
-    }
-}
-
-extension FallbackForClientRoutes : JsonSerializable
-{
-    public class var typeName:String { return "FallbackForClientRoutes" }
-    public class func reflect() -> Type<FallbackForClientRoutes> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<FallbackForClientRoutes>(
-            properties: [
-                Type<FallbackForClientRoutes>.optionalProperty("pathInfo", get: { $0.pathInfo }, set: { $0.pathInfo = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return FallbackForClientRoutes.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> FallbackForClientRoutes? {
-        return FallbackForClientRoutes.reflect().fromJson(FallbackForClientRoutes(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> FallbackForClientRoutes? {
-        return FallbackForClientRoutes.reflect().fromObject(FallbackForClientRoutes(), any:any)
-    }
-    public func toString() -> String {
-        return FallbackForClientRoutes.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> FallbackForClientRoutes? {
-        return FallbackForClientRoutes.reflect().fromString(FallbackForClientRoutes(), string: string)
-    }
-}
-
-extension ClientAllTechnologyStacks : JsonSerializable
-{
-    public class var typeName:String { return "ClientAllTechnologyStacks" }
-    public class func reflect() -> Type<ClientAllTechnologyStacks> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<ClientAllTechnologyStacks>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return ClientAllTechnologyStacks.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> ClientAllTechnologyStacks? {
-        return ClientAllTechnologyStacks.reflect().fromJson(ClientAllTechnologyStacks(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> ClientAllTechnologyStacks? {
-        return ClientAllTechnologyStacks.reflect().fromObject(ClientAllTechnologyStacks(), any:any)
-    }
-    public func toString() -> String {
-        return ClientAllTechnologyStacks.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> ClientAllTechnologyStacks? {
-        return ClientAllTechnologyStacks.reflect().fromString(ClientAllTechnologyStacks(), string: string)
-    }
-}
-
-extension ClientAllTechnologies : JsonSerializable
-{
-    public class var typeName:String { return "ClientAllTechnologies" }
-    public class func reflect() -> Type<ClientAllTechnologies> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<ClientAllTechnologies>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return ClientAllTechnologies.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> ClientAllTechnologies? {
-        return ClientAllTechnologies.reflect().fromJson(ClientAllTechnologies(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> ClientAllTechnologies? {
-        return ClientAllTechnologies.reflect().fromObject(ClientAllTechnologies(), any:any)
-    }
-    public func toString() -> String {
-        return ClientAllTechnologies.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> ClientAllTechnologies? {
-        return ClientAllTechnologies.reflect().fromString(ClientAllTechnologies(), string: string)
-    }
-}
-
-extension ClientTechnology : JsonSerializable
-{
-    public class var typeName:String { return "ClientTechnology" }
-    public class func reflect() -> Type<ClientTechnology> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<ClientTechnology>(
-            properties: [
-                Type<ClientTechnology>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return ClientTechnology.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> ClientTechnology? {
-        return ClientTechnology.reflect().fromJson(ClientTechnology(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> ClientTechnology? {
-        return ClientTechnology.reflect().fromObject(ClientTechnology(), any:any)
-    }
-    public func toString() -> String {
-        return ClientTechnology.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> ClientTechnology? {
-        return ClientTechnology.reflect().fromString(ClientTechnology(), string: string)
-    }
-}
-
-extension ClientUser : JsonSerializable
-{
-    public class var typeName:String { return "ClientUser" }
-    public class func reflect() -> Type<ClientUser> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<ClientUser>(
-            properties: [
-                Type<ClientUser>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return ClientUser.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> ClientUser? {
-        return ClientUser.reflect().fromJson(ClientUser(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> ClientUser? {
-        return ClientUser.reflect().fromObject(ClientUser(), any:any)
-    }
-    public func toString() -> String {
-        return ClientUser.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> ClientUser? {
-        return ClientUser.reflect().fromString(ClientUser(), string: string)
-    }
-}
-
-extension SessionInfo : JsonSerializable
-{
-    public class var typeName:String { return "SessionInfo" }
-    public class func reflect() -> Type<SessionInfo> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<SessionInfo>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return SessionInfo.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> SessionInfo? {
-        return SessionInfo.reflect().fromJson(SessionInfo(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> SessionInfo? {
-        return SessionInfo.reflect().fromObject(SessionInfo(), any:any)
-    }
-    public func toString() -> String {
-        return SessionInfo.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> SessionInfo? {
-        return SessionInfo.reflect().fromString(SessionInfo(), string: string)
-    }
-}
-
-extension CreateTechnology : JsonSerializable
-{
-    public class var typeName:String { return "CreateTechnology" }
-    public class func reflect() -> Type<CreateTechnology> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<CreateTechnology>(
-            properties: [
-                Type<CreateTechnology>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<CreateTechnology>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<CreateTechnology>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
-                Type<CreateTechnology>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
-                Type<CreateTechnology>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
-                Type<CreateTechnology>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<CreateTechnology>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<CreateTechnology>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return CreateTechnology.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> CreateTechnology? {
-        return CreateTechnology.reflect().fromJson(CreateTechnology(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> CreateTechnology? {
-        return CreateTechnology.reflect().fromObject(CreateTechnology(), any:any)
-    }
-    public func toString() -> String {
-        return CreateTechnology.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> CreateTechnology? {
-        return CreateTechnology.reflect().fromString(CreateTechnology(), string: string)
-    }
-}
-
-extension UpdateTechnology : JsonSerializable
-{
-    public class var typeName:String { return "UpdateTechnology" }
-    public class func reflect() -> Type<UpdateTechnology> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<UpdateTechnology>(
-            properties: [
-                Type<UpdateTechnology>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-                Type<UpdateTechnology>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<UpdateTechnology>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<UpdateTechnology>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
-                Type<UpdateTechnology>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
-                Type<UpdateTechnology>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
-                Type<UpdateTechnology>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<UpdateTechnology>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<UpdateTechnology>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return UpdateTechnology.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> UpdateTechnology? {
-        return UpdateTechnology.reflect().fromJson(UpdateTechnology(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> UpdateTechnology? {
-        return UpdateTechnology.reflect().fromObject(UpdateTechnology(), any:any)
-    }
-    public func toString() -> String {
-        return UpdateTechnology.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> UpdateTechnology? {
-        return UpdateTechnology.reflect().fromString(UpdateTechnology(), string: string)
-    }
-}
-
-extension DeleteTechnology : JsonSerializable
-{
-    public class var typeName:String { return "DeleteTechnology" }
-    public class func reflect() -> Type<DeleteTechnology> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<DeleteTechnology>(
-            properties: [
-                Type<DeleteTechnology>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return DeleteTechnology.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> DeleteTechnology? {
-        return DeleteTechnology.reflect().fromJson(DeleteTechnology(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> DeleteTechnology? {
-        return DeleteTechnology.reflect().fromObject(DeleteTechnology(), any:any)
-    }
-    public func toString() -> String {
-        return DeleteTechnology.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> DeleteTechnology? {
-        return DeleteTechnology.reflect().fromString(DeleteTechnology(), string: string)
-    }
-}
-
-extension GetTechnology : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnology" }
-    public class func reflect() -> Type<GetTechnology> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnology>(
-            properties: [
-                Type<GetTechnology>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-                Type<GetTechnology>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnology.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnology? {
-        return GetTechnology.reflect().fromJson(GetTechnology(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnology? {
-        return GetTechnology.reflect().fromObject(GetTechnology(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnology.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnology? {
-        return GetTechnology.reflect().fromString(GetTechnology(), string: string)
-    }
-}
-
-extension GetTechnologyPreviousVersions : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyPreviousVersions" }
-    public class func reflect() -> Type<GetTechnologyPreviousVersions> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyPreviousVersions>(
-            properties: [
-                Type<GetTechnologyPreviousVersions>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyPreviousVersions.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyPreviousVersions? {
-        return GetTechnologyPreviousVersions.reflect().fromJson(GetTechnologyPreviousVersions(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyPreviousVersions? {
-        return GetTechnologyPreviousVersions.reflect().fromObject(GetTechnologyPreviousVersions(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyPreviousVersions.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyPreviousVersions? {
-        return GetTechnologyPreviousVersions.reflect().fromString(GetTechnologyPreviousVersions(), string: string)
-    }
-}
-
-extension GetTechnologyFavoriteDetails : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyFavoriteDetails" }
-    public class func reflect() -> Type<GetTechnologyFavoriteDetails> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyFavoriteDetails>(
-            properties: [
-                Type<GetTechnologyFavoriteDetails>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<GetTechnologyFavoriteDetails>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyFavoriteDetails.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyFavoriteDetails? {
-        return GetTechnologyFavoriteDetails.reflect().fromJson(GetTechnologyFavoriteDetails(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyFavoriteDetails? {
-        return GetTechnologyFavoriteDetails.reflect().fromObject(GetTechnologyFavoriteDetails(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyFavoriteDetails.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyFavoriteDetails? {
-        return GetTechnologyFavoriteDetails.reflect().fromString(GetTechnologyFavoriteDetails(), string: string)
-    }
-}
-
-extension GetAllTechnologies : JsonSerializable
-{
-    public class var typeName:String { return "GetAllTechnologies" }
-    public class func reflect() -> Type<GetAllTechnologies> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetAllTechnologies>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return GetAllTechnologies.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetAllTechnologies? {
-        return GetAllTechnologies.reflect().fromJson(GetAllTechnologies(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetAllTechnologies? {
-        return GetAllTechnologies.reflect().fromObject(GetAllTechnologies(), any:any)
-    }
-    public func toString() -> String {
-        return GetAllTechnologies.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetAllTechnologies? {
-        return GetAllTechnologies.reflect().fromString(GetAllTechnologies(), string: string)
-    }
-}
-
-extension FindTechnologies : JsonSerializable
-{
-    public class var typeName:String { return "FindTechnologies" }
-    public class func reflect() -> Type<FindTechnologies> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<FindTechnologies>(
-            properties: [
-                Type<FindTechnologies>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<FindTechnologies>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-                Type<FindTechnologies>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
-                Type<FindTechnologies>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
-                Type<FindTechnologies>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
-                Type<FindTechnologies>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return FindTechnologies.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> FindTechnologies? {
-        return FindTechnologies.reflect().fromJson(FindTechnologies(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> FindTechnologies? {
-        return FindTechnologies.reflect().fromObject(FindTechnologies(), any:any)
-    }
-    public func toString() -> String {
-        return FindTechnologies.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> FindTechnologies? {
-        return FindTechnologies.reflect().fromString(FindTechnologies(), string: string)
-    }
-}
-
-extension CreateTechnologyStack : JsonSerializable
-{
-    public class var typeName:String { return "CreateTechnologyStack" }
-    public class func reflect() -> Type<CreateTechnologyStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<CreateTechnologyStack>(
-            properties: [
-                Type<CreateTechnologyStack>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<CreateTechnologyStack>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<CreateTechnologyStack>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
-                Type<CreateTechnologyStack>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
-                Type<CreateTechnologyStack>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<CreateTechnologyStack>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
-                Type<CreateTechnologyStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<CreateTechnologyStack>.arrayProperty("technologyIds", get: { $0.technologyIds }, set: { $0.technologyIds = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return CreateTechnologyStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> CreateTechnologyStack? {
-        return CreateTechnologyStack.reflect().fromJson(CreateTechnologyStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> CreateTechnologyStack? {
-        return CreateTechnologyStack.reflect().fromObject(CreateTechnologyStack(), any:any)
-    }
-    public func toString() -> String {
-        return CreateTechnologyStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> CreateTechnologyStack? {
-        return CreateTechnologyStack.reflect().fromString(CreateTechnologyStack(), string: string)
-    }
-}
-
-extension UpdateTechnologyStack : JsonSerializable
-{
-    public class var typeName:String { return "UpdateTechnologyStack" }
-    public class func reflect() -> Type<UpdateTechnologyStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<UpdateTechnologyStack>(
-            properties: [
-                Type<UpdateTechnologyStack>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-                Type<UpdateTechnologyStack>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
-                Type<UpdateTechnologyStack>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
-                Type<UpdateTechnologyStack>.optionalProperty("appUrl", get: { $0.appUrl }, set: { $0.appUrl = $1 }),
-                Type<UpdateTechnologyStack>.optionalProperty("screenshotUrl", get: { $0.screenshotUrl }, set: { $0.screenshotUrl = $1 }),
-                Type<UpdateTechnologyStack>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
-                Type<UpdateTechnologyStack>.optionalProperty("details", get: { $0.details }, set: { $0.details = $1 }),
-                Type<UpdateTechnologyStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
-                Type<UpdateTechnologyStack>.arrayProperty("technologyIds", get: { $0.technologyIds }, set: { $0.technologyIds = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return UpdateTechnologyStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> UpdateTechnologyStack? {
-        return UpdateTechnologyStack.reflect().fromJson(UpdateTechnologyStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> UpdateTechnologyStack? {
-        return UpdateTechnologyStack.reflect().fromObject(UpdateTechnologyStack(), any:any)
-    }
-    public func toString() -> String {
-        return UpdateTechnologyStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> UpdateTechnologyStack? {
-        return UpdateTechnologyStack.reflect().fromString(UpdateTechnologyStack(), string: string)
-    }
-}
-
-extension DeleteTechnologyStack : JsonSerializable
-{
-    public class var typeName:String { return "DeleteTechnologyStack" }
-    public class func reflect() -> Type<DeleteTechnologyStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<DeleteTechnologyStack>(
-            properties: [
-                Type<DeleteTechnologyStack>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return DeleteTechnologyStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> DeleteTechnologyStack? {
-        return DeleteTechnologyStack.reflect().fromJson(DeleteTechnologyStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> DeleteTechnologyStack? {
-        return DeleteTechnologyStack.reflect().fromObject(DeleteTechnologyStack(), any:any)
-    }
-    public func toString() -> String {
-        return DeleteTechnologyStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> DeleteTechnologyStack? {
-        return DeleteTechnologyStack.reflect().fromString(DeleteTechnologyStack(), string: string)
-    }
-}
-
-extension GetAllTechnologyStacks : JsonSerializable
-{
-    public class var typeName:String { return "GetAllTechnologyStacks" }
-    public class func reflect() -> Type<GetAllTechnologyStacks> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetAllTechnologyStacks>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return GetAllTechnologyStacks.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetAllTechnologyStacks? {
-        return GetAllTechnologyStacks.reflect().fromJson(GetAllTechnologyStacks(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetAllTechnologyStacks? {
-        return GetAllTechnologyStacks.reflect().fromObject(GetAllTechnologyStacks(), any:any)
-    }
-    public func toString() -> String {
-        return GetAllTechnologyStacks.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetAllTechnologyStacks? {
-        return GetAllTechnologyStacks.reflect().fromString(GetAllTechnologyStacks(), string: string)
-    }
-}
-
-extension GetTechnologyStack : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyStack" }
-    public class func reflect() -> Type<GetTechnologyStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyStack>(
-            properties: [
-                Type<GetTechnologyStack>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-                Type<GetTechnologyStack>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyStack? {
-        return GetTechnologyStack.reflect().fromJson(GetTechnologyStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyStack? {
-        return GetTechnologyStack.reflect().fromObject(GetTechnologyStack(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyStack? {
-        return GetTechnologyStack.reflect().fromString(GetTechnologyStack(), string: string)
-    }
-}
-
-extension GetTechnologyStackPreviousVersions : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyStackPreviousVersions" }
-    public class func reflect() -> Type<GetTechnologyStackPreviousVersions> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyStackPreviousVersions>(
-            properties: [
-                Type<GetTechnologyStackPreviousVersions>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyStackPreviousVersions.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyStackPreviousVersions? {
-        return GetTechnologyStackPreviousVersions.reflect().fromJson(GetTechnologyStackPreviousVersions(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyStackPreviousVersions? {
-        return GetTechnologyStackPreviousVersions.reflect().fromObject(GetTechnologyStackPreviousVersions(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyStackPreviousVersions.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyStackPreviousVersions? {
-        return GetTechnologyStackPreviousVersions.reflect().fromString(GetTechnologyStackPreviousVersions(), string: string)
-    }
-}
-
-extension GetTechnologyStackFavoriteDetails : JsonSerializable
-{
-    public class var typeName:String { return "GetTechnologyStackFavoriteDetails" }
-    public class func reflect() -> Type<GetTechnologyStackFavoriteDetails> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetTechnologyStackFavoriteDetails>(
-            properties: [
-                Type<GetTechnologyStackFavoriteDetails>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
-                Type<GetTechnologyStackFavoriteDetails>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetTechnologyStackFavoriteDetails.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetTechnologyStackFavoriteDetails? {
-        return GetTechnologyStackFavoriteDetails.reflect().fromJson(GetTechnologyStackFavoriteDetails(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetTechnologyStackFavoriteDetails? {
-        return GetTechnologyStackFavoriteDetails.reflect().fromObject(GetTechnologyStackFavoriteDetails(), any:any)
-    }
-    public func toString() -> String {
-        return GetTechnologyStackFavoriteDetails.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetTechnologyStackFavoriteDetails? {
-        return GetTechnologyStackFavoriteDetails.reflect().fromString(GetTechnologyStackFavoriteDetails(), string: string)
-    }
-}
-
-extension GetConfig : JsonSerializable
-{
-    public class var typeName:String { return "GetConfig" }
-    public class func reflect() -> Type<GetConfig> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetConfig>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return GetConfig.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetConfig? {
-        return GetConfig.reflect().fromJson(GetConfig(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetConfig? {
-        return GetConfig.reflect().fromObject(GetConfig(), any:any)
-    }
-    public func toString() -> String {
-        return GetConfig.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetConfig? {
-        return GetConfig.reflect().fromString(GetConfig(), string: string)
-    }
-}
-
-extension Overview : JsonSerializable
-{
-    public class var typeName:String { return "Overview" }
-    public class func reflect() -> Type<Overview> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<Overview>(
-            properties: [
-                Type<Overview>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return Overview.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> Overview? {
-        return Overview.reflect().fromJson(Overview(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> Overview? {
-        return Overview.reflect().fromObject(Overview(), any:any)
-    }
-    public func toString() -> String {
-        return Overview.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> Overview? {
-        return Overview.reflect().fromString(Overview(), string: string)
-    }
-}
-
-extension AppOverview : JsonSerializable
-{
-    public class var typeName:String { return "AppOverview" }
-    public class func reflect() -> Type<AppOverview> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<AppOverview>(
-            properties: [
-                Type<AppOverview>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return AppOverview.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> AppOverview? {
-        return AppOverview.reflect().fromJson(AppOverview(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> AppOverview? {
-        return AppOverview.reflect().fromObject(AppOverview(), any:any)
-    }
-    public func toString() -> String {
-        return AppOverview.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> AppOverview? {
-        return AppOverview.reflect().fromString(AppOverview(), string: string)
-    }
-}
-
-extension FindTechStacks : JsonSerializable
-{
-    public class var typeName:String { return "FindTechStacks" }
-    public class func reflect() -> Type<FindTechStacks> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<FindTechStacks>(
-            properties: [
-                Type<FindTechStacks>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-                Type<FindTechStacks>.optionalProperty("skip", get: { $0.skip }, set: { $0.skip = $1 }),
-                Type<FindTechStacks>.optionalProperty("take", get: { $0.take }, set: { $0.take = $1 }),
-                Type<FindTechStacks>.optionalProperty("orderBy", get: { $0.orderBy }, set: { $0.orderBy = $1 }),
-                Type<FindTechStacks>.optionalProperty("orderByDesc", get: { $0.orderByDesc }, set: { $0.orderByDesc = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return FindTechStacks.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> FindTechStacks? {
-        return FindTechStacks.reflect().fromJson(FindTechStacks(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> FindTechStacks? {
-        return FindTechStacks.reflect().fromObject(FindTechStacks(), any:any)
-    }
-    public func toString() -> String {
-        return FindTechStacks.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> FindTechStacks? {
-        return FindTechStacks.reflect().fromString(FindTechStacks(), string: string)
-    }
-}
-
-extension GetFavoriteTechStack : JsonSerializable
-{
-    public class var typeName:String { return "GetFavoriteTechStack" }
-    public class func reflect() -> Type<GetFavoriteTechStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetFavoriteTechStack>(
-            properties: [
-                Type<GetFavoriteTechStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetFavoriteTechStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetFavoriteTechStack? {
-        return GetFavoriteTechStack.reflect().fromJson(GetFavoriteTechStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetFavoriteTechStack? {
-        return GetFavoriteTechStack.reflect().fromObject(GetFavoriteTechStack(), any:any)
-    }
-    public func toString() -> String {
-        return GetFavoriteTechStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetFavoriteTechStack? {
-        return GetFavoriteTechStack.reflect().fromString(GetFavoriteTechStack(), string: string)
-    }
-}
-
-extension AddFavoriteTechStack : JsonSerializable
-{
-    public class var typeName:String { return "AddFavoriteTechStack" }
-    public class func reflect() -> Type<AddFavoriteTechStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<AddFavoriteTechStack>(
-            properties: [
-                Type<AddFavoriteTechStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return AddFavoriteTechStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> AddFavoriteTechStack? {
-        return AddFavoriteTechStack.reflect().fromJson(AddFavoriteTechStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> AddFavoriteTechStack? {
-        return AddFavoriteTechStack.reflect().fromObject(AddFavoriteTechStack(), any:any)
-    }
-    public func toString() -> String {
-        return AddFavoriteTechStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> AddFavoriteTechStack? {
-        return AddFavoriteTechStack.reflect().fromString(AddFavoriteTechStack(), string: string)
-    }
-}
-
-extension RemoveFavoriteTechStack : JsonSerializable
-{
-    public class var typeName:String { return "RemoveFavoriteTechStack" }
-    public class func reflect() -> Type<RemoveFavoriteTechStack> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<RemoveFavoriteTechStack>(
-            properties: [
-                Type<RemoveFavoriteTechStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return RemoveFavoriteTechStack.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> RemoveFavoriteTechStack? {
-        return RemoveFavoriteTechStack.reflect().fromJson(RemoveFavoriteTechStack(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> RemoveFavoriteTechStack? {
-        return RemoveFavoriteTechStack.reflect().fromObject(RemoveFavoriteTechStack(), any:any)
-    }
-    public func toString() -> String {
-        return RemoveFavoriteTechStack.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> RemoveFavoriteTechStack? {
-        return RemoveFavoriteTechStack.reflect().fromString(RemoveFavoriteTechStack(), string: string)
-    }
-}
-
-extension GetFavoriteTechnologies : JsonSerializable
-{
-    public class var typeName:String { return "GetFavoriteTechnologies" }
-    public class func reflect() -> Type<GetFavoriteTechnologies> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetFavoriteTechnologies>(
-            properties: [
-                Type<GetFavoriteTechnologies>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetFavoriteTechnologies.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetFavoriteTechnologies? {
-        return GetFavoriteTechnologies.reflect().fromJson(GetFavoriteTechnologies(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetFavoriteTechnologies? {
-        return GetFavoriteTechnologies.reflect().fromObject(GetFavoriteTechnologies(), any:any)
-    }
-    public func toString() -> String {
-        return GetFavoriteTechnologies.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetFavoriteTechnologies? {
-        return GetFavoriteTechnologies.reflect().fromString(GetFavoriteTechnologies(), string: string)
-    }
-}
-
-extension AddFavoriteTechnology : JsonSerializable
-{
-    public class var typeName:String { return "AddFavoriteTechnology" }
-    public class func reflect() -> Type<AddFavoriteTechnology> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<AddFavoriteTechnology>(
-            properties: [
-                Type<AddFavoriteTechnology>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return AddFavoriteTechnology.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> AddFavoriteTechnology? {
-        return AddFavoriteTechnology.reflect().fromJson(AddFavoriteTechnology(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> AddFavoriteTechnology? {
-        return AddFavoriteTechnology.reflect().fromObject(AddFavoriteTechnology(), any:any)
-    }
-    public func toString() -> String {
-        return AddFavoriteTechnology.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> AddFavoriteTechnology? {
-        return AddFavoriteTechnology.reflect().fromString(AddFavoriteTechnology(), string: string)
-    }
-}
-
-extension RemoveFavoriteTechnology : JsonSerializable
-{
-    public class var typeName:String { return "RemoveFavoriteTechnology" }
-    public class func reflect() -> Type<RemoveFavoriteTechnology> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<RemoveFavoriteTechnology>(
-            properties: [
-                Type<RemoveFavoriteTechnology>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return RemoveFavoriteTechnology.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> RemoveFavoriteTechnology? {
-        return RemoveFavoriteTechnology.reflect().fromJson(RemoveFavoriteTechnology(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> RemoveFavoriteTechnology? {
-        return RemoveFavoriteTechnology.reflect().fromObject(RemoveFavoriteTechnology(), any:any)
-    }
-    public func toString() -> String {
-        return RemoveFavoriteTechnology.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> RemoveFavoriteTechnology? {
-        return RemoveFavoriteTechnology.reflect().fromString(RemoveFavoriteTechnology(), string: string)
-    }
-}
-
-extension GetUserFeed : JsonSerializable
-{
-    public class var typeName:String { return "GetUserFeed" }
-    public class func reflect() -> Type<GetUserFeed> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetUserFeed>(
-            properties: [
-            ]))
-    }
-    public func toJson() -> String {
-        return GetUserFeed.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetUserFeed? {
-        return GetUserFeed.reflect().fromJson(GetUserFeed(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetUserFeed? {
-        return GetUserFeed.reflect().fromObject(GetUserFeed(), any:any)
-    }
-    public func toString() -> String {
-        return GetUserFeed.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetUserFeed? {
-        return GetUserFeed.reflect().fromString(GetUserFeed(), string: string)
-    }
-}
-
-extension GetUserInfo : JsonSerializable
-{
-    public class var typeName:String { return "GetUserInfo" }
-    public class func reflect() -> Type<GetUserInfo> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<GetUserInfo>(
-            properties: [
-                Type<GetUserInfo>.optionalProperty("reload", get: { $0.reload }, set: { $0.reload = $1 }),
-                Type<GetUserInfo>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return GetUserInfo.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> GetUserInfo? {
-        return GetUserInfo.reflect().fromJson(GetUserInfo(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> GetUserInfo? {
-        return GetUserInfo.reflect().fromObject(GetUserInfo(), any:any)
-    }
-    public func toString() -> String {
-        return GetUserInfo.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> GetUserInfo? {
-        return GetUserInfo.reflect().fromString(GetUserInfo(), string: string)
-    }
-}
-
-extension Authenticate : JsonSerializable
-{
-    public class var typeName:String { return "Authenticate" }
-    public class func reflect() -> Type<Authenticate> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<Authenticate>(
-            properties: [
-                Type<Authenticate>.optionalProperty("provider", get: { $0.provider }, set: { $0.provider = $1 }),
-                Type<Authenticate>.optionalProperty("state", get: { $0.state }, set: { $0.state = $1 }),
-                Type<Authenticate>.optionalProperty("oauth_token", get: { $0.oauth_token }, set: { $0.oauth_token = $1 }),
-                Type<Authenticate>.optionalProperty("oauth_verifier", get: { $0.oauth_verifier }, set: { $0.oauth_verifier = $1 }),
-                Type<Authenticate>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
-                Type<Authenticate>.optionalProperty("password", get: { $0.password }, set: { $0.password = $1 }),
-                Type<Authenticate>.optionalProperty("rememberMe", get: { $0.rememberMe }, set: { $0.rememberMe = $1 }),
-                Type<Authenticate>.optionalProperty("Continue", get: { $0.Continue }, set: { $0.Continue = $1 }),
-                Type<Authenticate>.optionalProperty("nonce", get: { $0.nonce }, set: { $0.nonce = $1 }),
-                Type<Authenticate>.optionalProperty("uri", get: { $0.uri }, set: { $0.uri = $1 }),
-                Type<Authenticate>.optionalProperty("response", get: { $0.response }, set: { $0.response = $1 }),
-                Type<Authenticate>.optionalProperty("qop", get: { $0.qop }, set: { $0.qop = $1 }),
-                Type<Authenticate>.optionalProperty("nc", get: { $0.nc }, set: { $0.nc = $1 }),
-                Type<Authenticate>.optionalProperty("cnonce", get: { $0.cnonce }, set: { $0.cnonce = $1 }),
-                Type<Authenticate>.objectProperty("meta", get: { $0.meta }, set: { $0.meta = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return Authenticate.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> Authenticate? {
-        return Authenticate.reflect().fromJson(Authenticate(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> Authenticate? {
-        return Authenticate.reflect().fromObject(Authenticate(), any:any)
-    }
-    public func toString() -> String {
-        return Authenticate.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> Authenticate? {
-        return Authenticate.reflect().fromString(Authenticate(), string: string)
-    }
-} 
-
-extension AssignRoles : JsonSerializable
-{
-    public class var typeName:String { return "AssignRoles" }
-    public class func reflect() -> Type<AssignRoles> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<AssignRoles>(
-            properties: [
-                Type<AssignRoles>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
-                Type<AssignRoles>.arrayProperty("permissions", get: { $0.permissions }, set: { $0.permissions = $1 }),
-                Type<AssignRoles>.arrayProperty("roles", get: { $0.roles }, set: { $0.roles = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return AssignRoles.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> AssignRoles? {
-        return AssignRoles.reflect().fromJson(AssignRoles(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> AssignRoles? {
-        return AssignRoles.reflect().fromObject(AssignRoles(), any:any)
-    }
-    public func toString() -> String {
-        return AssignRoles.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> AssignRoles? {
-        return AssignRoles.reflect().fromString(AssignRoles(), string: string)
-    }
-}
-
-extension UnAssignRoles : JsonSerializable
-{
-    public class var typeName:String { return "UnAssignRoles" }
-    public class func reflect() -> Type<UnAssignRoles> {
-        return TypeConfig.config() ?? TypeConfig.configure(Type<UnAssignRoles>(
-            properties: [
-                Type<UnAssignRoles>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
-                Type<UnAssignRoles>.arrayProperty("permissions", get: { $0.permissions }, set: { $0.permissions = $1 }),
-                Type<UnAssignRoles>.arrayProperty("roles", get: { $0.roles }, set: { $0.roles = $1 }),
-            ]))
-    }
-    public func toJson() -> String {
-        return UnAssignRoles.reflect().toJson(self)
-    }
-    public class func fromJson(json:String) -> UnAssignRoles? {
-        return UnAssignRoles.reflect().fromJson(UnAssignRoles(), json: json)
-    }
-    public class func fromObject(any:AnyObject) -> UnAssignRoles? {
-        return UnAssignRoles.reflect().fromObject(UnAssignRoles(), any:any)
-    }
-    public func toString() -> String {
-        return UnAssignRoles.reflect().toString(self)
-    }
-    public class func fromString(string:String) -> UnAssignRoles? {
-        return UnAssignRoles.reflect().fromString(UnAssignRoles(), string: string)
-    }
+    public static var typeName:String { return "TechnologyInStack" }
+    public static var metadata = Metadata.create([
+        Type<TechnologyInStack>.optionalProperty("technologyId", get: { $0.technologyId }, set: { $0.technologyId = $1 }),
+        Type<TechnologyInStack>.optionalProperty("technologyStackId", get: { $0.technologyStackId }, set: { $0.technologyStackId = $1 }),
+        Type<TechnologyInStack>.optionalProperty("justification", get: { $0.justification }, set: { $0.justification = $1 }),
+        Type<TechnologyInStack>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<TechnologyInStack>.optionalProperty("name", get: { $0.name }, set: { $0.name = $1 }),
+        Type<TechnologyInStack>.optionalProperty("vendorName", get: { $0.vendorName }, set: { $0.vendorName = $1 }),
+        Type<TechnologyInStack>.optionalProperty("vendorUrl", get: { $0.vendorUrl }, set: { $0.vendorUrl = $1 }),
+        Type<TechnologyInStack>.optionalProperty("productUrl", get: { $0.productUrl }, set: { $0.productUrl = $1 }),
+        Type<TechnologyInStack>.optionalProperty("logoUrl", get: { $0.logoUrl }, set: { $0.logoUrl = $1 }),
+        Type<TechnologyInStack>.optionalProperty("Description", get: { $0.Description }, set: { $0.Description = $1 }),
+        Type<TechnologyInStack>.optionalProperty("created", get: { $0.created }, set: { $0.created = $1 }),
+        Type<TechnologyInStack>.optionalProperty("createdBy", get: { $0.createdBy }, set: { $0.createdBy = $1 }),
+        Type<TechnologyInStack>.optionalProperty("lastModified", get: { $0.lastModified }, set: { $0.lastModified = $1 }),
+        Type<TechnologyInStack>.optionalProperty("lastModifiedBy", get: { $0.lastModifiedBy }, set: { $0.lastModifiedBy = $1 }),
+        Type<TechnologyInStack>.optionalProperty("ownerId", get: { $0.ownerId }, set: { $0.ownerId = $1 }),
+        Type<TechnologyInStack>.optionalProperty("slug", get: { $0.slug }, set: { $0.slug = $1 }),
+        Type<TechnologyInStack>.optionalProperty("logoApproved", get: { $0.logoApproved }, set: { $0.logoApproved = $1 }),
+        Type<TechnologyInStack>.optionalProperty("isLocked", get: { $0.isLocked }, set: { $0.isLocked = $1 }),
+        Type<TechnologyInStack>.optionalProperty("tier", get: { $0.tier }, set: { $0.tier = $1 }),
+        Type<TechnologyInStack>.optionalProperty("lastStatusUpdate", get: { $0.lastStatusUpdate }, set: { $0.lastStatusUpdate = $1 }),
+        ])
+}
+
+extension PostComment : JsonSerializable
+{
+    public static var typeName:String { return "PostComment" }
+    public static var metadata = Metadata.create([
+        Type<PostComment>.optionalProperty("id", get: { $0.id }, set: { $0.id = $1 }),
+        Type<PostComment>.optionalProperty("postId", get: { $0.postId }, set: { $0.postId = $1 }),
+        Type<PostComment>.optionalProperty("userId", get: { $0.userId }, set: { $0.userId = $1 }),
+        Type<PostComment>.optionalProperty("userName", get: { $0.userName }, set: { $0.userName = $1 }),
+        Type<PostComment>.optionalProperty("date", get: { $0.date }, set: { $0.date = $1 }),
+        Type<PostComment>.optionalProperty("shortDate", get: { $0.shortDate }, set: { $0.shortDate = $1 }),
+        Type<PostComment>.optionalProperty("textHtml", get: { $0.textHtml }, set: { $0.textHtml = $1 }),
+        ])
 }

--- a/src/TechStacks/TechnologyDetailViewController.swift
+++ b/src/TechStacks/TechnologyDetailViewController.swift
@@ -47,7 +47,7 @@ class TechnologyDetailViewController : UIViewController, UITableViewDelegate, UI
         self.title = "loading \(name)..."
 
         appData.loadTechnology(slug)
-            .then(body: { (r:GetTechnologyResponse) -> Void in
+            .then({ (r:GetTechnologyResponse) -> Void in
                 if let technology = r.technology {
                     self.technology = r.technology
                     self.title = "Technology"
@@ -76,7 +76,9 @@ class TechnologyDetailViewController : UIViewController, UITableViewDelegate, UI
                     self.lblDescription.frame = CGRect(
                         x: pad, y: logoBounds.height,
                         width: innerWidth, height: Style.detailSize.lineHeight)
-                    self.lblDescription.font = self.lblDescription.font.fontWithSize(Style.detailSize)
+                    if let f = self.lblDescription.font?.fontWithSize(Style.detailSize) {
+                        self.lblDescription.font = f
+                    }
                     self.lblDescription.sizeToFit()
                     
                     let tblOffset = self.lblDescription.frame.origin.y + self.lblDescription.frame.height + pad
@@ -86,7 +88,7 @@ class TechnologyDetailViewController : UIViewController, UITableViewDelegate, UI
                         width: fullWidth, height: self.view.frame.height - tblOffset - 54 /* bottom bar */)
 
                     self.imgLogo.loadAsync(technology.logoUrl, withSize:logoBounds)
-                        .then(body: { (img:UIImage?) -> Void in
+                        .then({ (img:UIImage?) -> Void in
                             if img != nil {
                                 self.imgLogo.frame.origin = CGPoint(x: fullWidth - img!.size.width - pad, y: 0)
                             }
@@ -109,9 +111,9 @@ class TechnologyDetailViewController : UIViewController, UITableViewDelegate, UI
         let selected = technologyStacks[indexPath.row]
         
         // Note: Should not be necessary but current iOS 8.0 bug requires it.
-        tableView.deselectRowAtIndexPath(tableView.indexPathForSelectedRow()!, animated: false)
-
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "Back", style: UIBarButtonItemStyle.Bordered, target: nil, action: nil)
+        tableView.deselectRowAtIndexPath(tableView.indexPathForSelectedRow!, animated: false)
+        
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "Back", style: .Plain, target: nil, action: nil)
         self.navigationController?.openTechnologyStack(selected.slug!)
     }
     

--- a/src/TechStacks/TechnologyStackDetailViewController.swift
+++ b/src/TechStacks/TechnologyStackDetailViewController.swift
@@ -40,7 +40,7 @@ class TechnologyStackDetailViewController : UIViewController {
         lblName.text = "loading \(name)..."
 
         appData.loadTechnologyStack(slug)
-            .then(body: { (r:GetTechnologyStackResponse) -> Void in
+            .then({ (r:GetTechnologyStackResponse) -> Void in
                 if let result = r.result {
                     self.result = result
                     self.title = "TechStack"
@@ -60,14 +60,16 @@ class TechnologyStackDetailViewController : UIViewController {
     func calculateLayout() {
         let pad = Style.padding
         
-        var fullWidth = view.frame.width
-        var innerWidth = fullWidth - (pad * 2)
+        let fullWidth = view.frame.width
+        let innerWidth = fullWidth - (pad * 2)
         
         lblName.frame = CGRect(x: pad, y: pad, width: innerWidth, height: Style.titleSize.lineHeight)
         lblName.font = lblName.font.fontWithSize(Style.titleSize)
 
         lblDescription.frame = CGRect(x: pad, y:pad + lblName.frame.size.height + pad, width:innerWidth, height: Style.detailSize.lineHeight)
-        lblDescription.font = lblDescription.font.fontWithSize(Style.detailSize)
+        if let f = lblDescription.font?.fontWithSize(Style.detailSize) {
+            lblDescription.font = f
+        }
         lblDescription.sizeToFit()
 
         imgScreenshot.frame = CGRect(
@@ -76,7 +78,7 @@ class TechnologyStackDetailViewController : UIViewController {
             width: Style.screenshotWidth,
             height: Style.screenshotHeight)
         
-        var btnAppUrl = UIButton.buttonWithType(UIButtonType.System) as UIButton
+        let btnAppUrl = UIButton(type: UIButtonType.System)
         btnAppUrl.frame = CGRect(x: imgScreenshot.frame.origin.x,
                 y: imgScreenshot.frame.origin.y + imgScreenshot.frame.size.height,
                 width: imgScreenshot.frame.width,
@@ -89,11 +91,11 @@ class TechnologyStackDetailViewController : UIViewController {
     var techSlugs = [String]()
 
     func loadTechnologies(techChoices:[TechnologyInStack]) {
-        var imageUrls = techChoices.filter { $0.logoUrl != nil }.map { $0.logoUrl! }
+        let imageUrls = techChoices.filter { $0.logoUrl != nil }.map { $0.logoUrl! }
         let fullWidth = self.view.frame.width
         
         self.appData.loadAllImagesAsync(imageUrls)
-            .then(body: { (images:[String:UIImage?]) -> Void in
+            .then({ (images:[String:UIImage?]) -> Void in
                 let pad = Style.padding
                 let btnAppUrlSize:CGFloat = 20
                 var startPos = self.imgScreenshot.frame.origin.y + self.imgScreenshot.frame.size.height + pad + btnAppUrlSize
@@ -102,7 +104,7 @@ class TechnologyStackDetailViewController : UIViewController {
                     let techologiesInTier = techChoices.filter { $0.tier == tier.value }
                     if techologiesInTier.count > 0 {
                         startPos += pad
-                        var title = UILabel(frame: CGRectMake(pad, startPos + pad, fullWidth, Style.headingSize.lineHeight))
+                        let title = UILabel(frame: CGRectMake(pad, startPos + pad, fullWidth, Style.headingSize.lineHeight))
                         title.font = UIFont(name: title.font.fontName, size: Style.headingSize)
                         startPos += Style.headingSize
                         
@@ -123,7 +125,7 @@ class TechnologyStackDetailViewController : UIViewController {
                                 i++
                                 startPos += pad
                                 let x = i % 2 == 1 ? pad : fullWidth / 2 + pad
-                                var imgBtn = UIButton(frame: CGRect(x: x, y: startPos, width: fullWidth / 2 - (2 * pad), height: Style.techLogoHeight))
+                                let imgBtn = UIButton(frame: CGRect(x: x, y: startPos, width: fullWidth / 2 - (2 * pad), height: Style.techLogoHeight))
                                 if i % 2 == 0 {
                                     startPos += Style.techLogoHeight
                                 }
@@ -148,7 +150,7 @@ class TechnologyStackDetailViewController : UIViewController {
     
     func onTechnologySelected(sender:UIButton) {
         let slug = techSlugs[sender.tag]
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "Back", style: UIBarButtonItemStyle.Bordered, target: nil, action: nil)
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "Back", style: .Plain, target: nil, action: nil)
         self.navigationController?.openTechnology(slug)
     }
     

--- a/src/TechStacks/UIExtensions.swift
+++ b/src/TechStacks/UIExtensions.swift
@@ -78,7 +78,7 @@ func deviceSizes(iphone:CGFloat, ipad:CGFloat) -> CGFloat {
 extension UIStoryboard
 {    
     func headerViewController() -> UIViewController {
-        let headerController = self.instantiateViewControllerWithIdentifier("HeaderViewController") as HeaderViewController
+        let headerController = self.instantiateViewControllerWithIdentifier("HeaderViewController") as! HeaderViewController
         let view:UIView = headerController.view!
         var frame = view.frame
         frame.size.height = 60
@@ -89,11 +89,11 @@ extension UIStoryboard
     
     var tabControler:UITabBarController {
         let window = UIApplication.sharedApplication().keyWindow!
-        return window.rootViewController as UITabBarController
+        return window.rootViewController as! UITabBarController
     }
     
     func openTechnologyStack(slug:String, goBackToTab:MainTab? = nil) {
-        let detail = self.instantiateViewControllerWithIdentifier("TechnologyStackDetailViewController") as TechnologyStackDetailViewController
+        let detail = self.instantiateViewControllerWithIdentifier("TechnologyStackDetailViewController") as! TechnologyStackDetailViewController
         detail.slug = slug
         if goBackToTab != nil {
             detail.goBackToTab = goBackToTab
@@ -106,7 +106,7 @@ extension UIStoryboard
     }
     
     func openTechnology(slug:String, goBackToTab:MainTab? = nil) {
-        let detail = self.instantiateViewControllerWithIdentifier("TechnologyDetailViewController") as TechnologyDetailViewController
+        let detail = self.instantiateViewControllerWithIdentifier("TechnologyDetailViewController") as! TechnologyDetailViewController
         detail.slug = slug
         if goBackToTab != nil {
             detail.goBackToTab = goBackToTab
@@ -129,14 +129,14 @@ extension UIStoryboard
 extension UIView
 {
     var appData:AppData {
-        return (UIApplication.sharedApplication().delegate as AppDelegate).appData
+        return (UIApplication.sharedApplication().delegate as! AppDelegate).appData
     }
 }
 
 extension UIViewController
 {
     var appData:AppData {
-        return (UIApplication.sharedApplication().delegate as AppDelegate).appData
+        return (UIApplication.sharedApplication().delegate as! AppDelegate).appData
     }
     
     func openServiceStack() {
@@ -152,14 +152,14 @@ extension UIViewController
 extension UINavigationController
 {
     func openTechnologyStack(slug:String) {
-        let detail = self.storyboard!.instantiateViewControllerWithIdentifier("TechnologyStackDetailViewController") as TechnologyStackDetailViewController
+        let detail = self.storyboard!.instantiateViewControllerWithIdentifier("TechnologyStackDetailViewController") as! TechnologyStackDetailViewController
         detail.slug = slug
         detail.navigationController?.navigationBar.backItem?.title = "Back"
         self.pushViewController(detail, animated: true)
     }
     
     func openTechnology(slug:String) {
-        let detail = self.storyboard!.instantiateViewControllerWithIdentifier("TechnologyDetailViewController") as TechnologyDetailViewController
+        let detail = self.storyboard!.instantiateViewControllerWithIdentifier("TechnologyDetailViewController") as! TechnologyDetailViewController
         detail.slug = slug
         detail.navigationController?.navigationBar.backItem?.title = "Back"
         self.pushViewController(detail, animated: true)
@@ -198,7 +198,7 @@ extension UIImageView {
         }
         
         return self.appData.loadImageAsync(url!)
-            .then(body: {(img:UIImage?) -> UIImage? in
+            .then({(img:UIImage?) -> UIImage? in
                 if img != nil {
                     
                     if withSize != nil {
@@ -237,9 +237,9 @@ extension UIImage
         scaledSize.height = self.size.height * useRatio
         
         UIGraphicsBeginImageContextWithOptions(scaledSize, false, 0.0)
-        var scaledImageRect = CGRectMake(0.0, 0.0, scaledSize.width, scaledSize.height)
+        let scaledImageRect = CGRectMake(0.0, 0.0, scaledSize.width, scaledSize.height)
         self.drawInRect(scaledImageRect)
-        var scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         
         return scaledImage
@@ -255,10 +255,10 @@ extension UILabel
 
 extension String {
     func toHumanFriendlyUrl() -> String {
-        if self.count == 0 {
+        if self.length == 0 {
             return ""
         }
-        var url = splitOnFirst("://").last!
+        let url = splitOnFirst("://").last!
         return url.stringByTrimmingCharactersInSet(NSCharacterSet(charactersInString: "/"))
     }
 }


### PR DESCRIPTION
Update to Swift 2.0 ... Incorporated some of the default recommendations like reformatting the bundle identifier. Also updated to the latest JsonServiceClient, and the latest auto-generated DTO file from techstacks.io/types/swift ... Added an extra file "... .dtos.extras.swift" for the autoquery DTOs. General refactoring for other Swift 2.0 conventions ... Had to add a few new properties in the info.plist file to allow for http connections (iOS 9 now requires it apparently).  General testing only on various emulators (5s, 6, 6plus, 6s, ipad air 2). Did not test on physical device, as I did not want to mess with provisioning profiles and signing the build, and risking altering the project.
